### PR TITLE
TPSDWAN-459: Fixed DeviceTypes 

### DIFF
--- a/sdwan/resource_sdwan_system_feature_template.go
+++ b/sdwan/resource_sdwan_system_feature_template.go
@@ -35,6 +35,7 @@ func resourceSDWANSystemFeatureTemplate() *schema.Resource {
 			"device_type": {
 				Type:     schema.TypeList,
 				Required: true,
+				ForceNew: true,
 				MinItems: 1,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
The user was able to provide incompatible Device Types during the Update.
Fixed it by making the DeviceType as ForceNew: true