### PR TITLE
fix: Typo in IPv6 variables

### DIFF
--- a/docs/data-sources/cisco_vpn_interface_feature_template.md
+++ b/docs/data-sources/cisco_vpn_interface_feature_template.md
@@ -351,7 +351,7 @@ Read-Only:
 
 - `group_id` (Number) Group ID
 - `group_id_variable` (String) Variable name
-- `ipv6_adresses` (Attributes List) IPv6 VRRP (see [below for nested schema](#nestedatt--ipv6_vrrps--ipv6_adresses))
+- `ipv6_addresses` (Attributes List) IPv6 VRRP (see [below for nested schema](#nestedatt--ipv6_vrrps--ipv6_addresses))
 - `optional` (Boolean) Indicates if list item is considered optional.
 - `priority` (Number) Set priority
 - `priority_variable` (String) Variable name
@@ -362,8 +362,8 @@ Read-Only:
 - `track_prefix_list` (String) Track Prefix List
 - `track_prefix_list_variable` (String) Variable name
 
-<a id="nestedatt--ipv6_vrrps--ipv6_adresses"></a>
-### Nested Schema for `ipv6_vrrps.ipv6_adresses`
+<a id="nestedatt--ipv6_vrrps--ipv6_addresses"></a>
+### Nested Schema for `ipv6_vrrps.ipv6_addresses`
 
 Read-Only:
 

--- a/docs/resources/cisco_vpn_interface_feature_template.md
+++ b/docs/resources/cisco_vpn_interface_feature_template.md
@@ -213,7 +213,7 @@ resource "sdwan_cisco_vpn_interface_feature_template" "example" {
       timer             = 100
       track_omp         = false
       track_prefix_list = "PL1"
-      ipv6_adresses = [
+      ipv6_addresses = [
         {
           ipv6_link_local = "fe80::260:8ff:fe52:f9d8"
           prefix          = "2001:9::/48"
@@ -680,7 +680,7 @@ Optional:
 - `group_id` (Number) Group ID
   - Range: `1`-`255`
 - `group_id_variable` (String) Variable name
-- `ipv6_adresses` (Attributes List) IPv6 VRRP (see [below for nested schema](#nestedatt--ipv6_vrrps--ipv6_adresses))
+- `ipv6_addresses` (Attributes List) IPv6 VRRP (see [below for nested schema](#nestedatt--ipv6_vrrps--ipv6_addresses))
 - `optional` (Boolean) Indicates if list item is considered optional.
 - `priority` (Number) Set priority
   - Range: `1`-`254`
@@ -696,8 +696,8 @@ Optional:
 - `track_prefix_list` (String) Track Prefix List
 - `track_prefix_list_variable` (String) Variable name
 
-<a id="nestedatt--ipv6_vrrps--ipv6_adresses"></a>
-### Nested Schema for `ipv6_vrrps.ipv6_adresses`
+<a id="nestedatt--ipv6_vrrps--ipv6_addresses"></a>
+### Nested Schema for `ipv6_vrrps.ipv6_addresses`
 
 Optional:
 

--- a/examples/resources/sdwan_cisco_vpn_interface_feature_template/resource.tf
+++ b/examples/resources/sdwan_cisco_vpn_interface_feature_template/resource.tf
@@ -196,7 +196,7 @@ resource "sdwan_cisco_vpn_interface_feature_template" "example" {
       timer             = 100
       track_omp         = false
       track_prefix_list = "PL1"
-      ipv6_adresses = [
+      ipv6_addresses = [
         {
           ipv6_link_local = "fe80::260:8ff:fe52:f9d8"
           prefix          = "2001:9::/48"

--- a/gen/definitions/feature_templates/cisco_vpn_interface.yaml
+++ b/gen/definitions/feature_templates/cisco_vpn_interface.yaml
@@ -451,7 +451,7 @@ attributes:
       - model_name: track-prefix-list
         example: PL1
       - model_name: ipv6
-        tf_name: ipv6_adresses
+        tf_name: ipv6_addresses
         attributes:
           - model_name: ipv6-link-local
             example: fe80::260:8ff:fe52:f9d8

--- a/gen/definitions/generic/centralized_policy.yaml
+++ b/gen/definitions/generic/centralized_policy.yaml
@@ -54,7 +54,7 @@ attributes:
             data,
           ]
         mandatory: true
-        description: Policy definiton type
+        description: Policy definition type
         example: data
       - model_name: entries
         tf_name: entries

--- a/gen/definitions/generic/localized_policy.yaml
+++ b/gen/definitions/generic/localized_policy.yaml
@@ -25,28 +25,28 @@ attributes:
     data_path: [policyDefinition, settings]
     tf_name: flow_visibility_ipv4
     type: Bool
-    description: IPv4 flow visibilty
+    description: IPv4 flow visibility
     default_value: true
     example: true
   - model_name: flowVisibilityIPv6
     data_path: [policyDefinition, settings]
     tf_name: flow_visibility_ipv6
     type: Bool
-    description: IPv6 flow visibilty
+    description: IPv6 flow visibility
     default_value: true
     example: true
   - model_name: appVisibility
     data_path: [policyDefinition, settings]
     tf_name: application_visibility_ipv4
     type: Bool
-    description: IPv4 application visibilty
+    description: IPv4 application visibility
     default_value: true
     example: true
   - model_name: appVisibilityIPv6
     data_path: [policyDefinition, settings]
     tf_name: application_visibility_ipv6
     type: Bool
-    description: IPv6 application visibilty
+    description: IPv6 application visibility
     default_value: true
     example: true
   - model_name: cloudQos
@@ -117,7 +117,7 @@ attributes:
         tf_name: type
         type: String
         mandatory: true
-        description: Policy definiton type
+        description: Policy definition type
         example: acl
 
 test_prerequisites: |

--- a/internal/provider/data_source_sdwan_centralized_policy.go
+++ b/internal/provider/data_source_sdwan_centralized_policy.go
@@ -84,7 +84,7 @@ func (d *CentralizedPolicyDataSource) Schema(ctx context.Context, req datasource
 							Computed:            true,
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: "Policy definiton type",
+							MarkdownDescription: "Policy definition type",
 							Computed:            true,
 						},
 						"entries": schema.SetNestedAttribute{

--- a/internal/provider/data_source_sdwan_cisco_vpn_interface_feature_template.go
+++ b/internal/provider/data_source_sdwan_cisco_vpn_interface_feature_template.go
@@ -1333,7 +1333,7 @@ func (d *CiscoVPNInterfaceFeatureTemplateDataSource) Schema(ctx context.Context,
 							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 							Computed:            true,
 						},
-						"ipv6_adresses": schema.ListNestedAttribute{
+						"ipv6_addresses": schema.ListNestedAttribute{
 							MarkdownDescription: "IPv6 VRRP",
 							Computed:            true,
 							NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/data_source_sdwan_cisco_vpn_interface_feature_template_test.go
+++ b/internal/provider/data_source_sdwan_cisco_vpn_interface_feature_template_test.go
@@ -169,8 +169,8 @@ func TestAccDataSourceSdwanCiscoVPNInterfaceFeatureTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.timer", "100"),
 					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.track_omp", "false"),
 					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.track_prefix_list", "PL1"),
-					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_adresses.0.ipv6_link_local", "fe80::260:8ff:fe52:f9d8"),
-					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_adresses.0.prefix", "2001:9::/48"),
+					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_addresses.0.ipv6_link_local", "fe80::260:8ff:fe52:f9d8"),
+					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_addresses.0.prefix", "2001:9::/48"),
 					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "propagate_sgt", "false"),
 					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "static_sgt", "1003"),
 					resource.TestCheckResourceAttr("data.sdwan_cisco_vpn_interface_feature_template.test", "static_sgt_trusted", "false"),
@@ -356,7 +356,7 @@ resource "sdwan_cisco_vpn_interface_feature_template" "test" {
     timer = 100
     track_omp = false
     track_prefix_list = "PL1"
-	ipv6_adresses = [{
+	ipv6_addresses = [{
 		ipv6_link_local = "fe80::260:8ff:fe52:f9d8"
 		prefix = "2001:9::/48"
 	}]

--- a/internal/provider/data_source_sdwan_localized_policy.go
+++ b/internal/provider/data_source_sdwan_localized_policy.go
@@ -70,19 +70,19 @@ func (d *LocalizedPolicyDataSource) Schema(ctx context.Context, req datasource.S
 				Computed:            true,
 			},
 			"flow_visibility_ipv4": schema.BoolAttribute{
-				MarkdownDescription: "IPv4 flow visibilty",
+				MarkdownDescription: "IPv4 flow visibility",
 				Computed:            true,
 			},
 			"flow_visibility_ipv6": schema.BoolAttribute{
-				MarkdownDescription: "IPv6 flow visibilty",
+				MarkdownDescription: "IPv6 flow visibility",
 				Computed:            true,
 			},
 			"application_visibility_ipv4": schema.BoolAttribute{
-				MarkdownDescription: "IPv4 application visibilty",
+				MarkdownDescription: "IPv4 application visibility",
 				Computed:            true,
 			},
 			"application_visibility_ipv6": schema.BoolAttribute{
-				MarkdownDescription: "IPv6 application visibilty",
+				MarkdownDescription: "IPv6 application visibility",
 				Computed:            true,
 			},
 			"cloud_qos": schema.BoolAttribute{
@@ -123,7 +123,7 @@ func (d *LocalizedPolicyDataSource) Schema(ctx context.Context, req datasource.S
 							Computed:            true,
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: "Policy definiton type",
+							MarkdownDescription: "Policy definition type",
 							Computed:            true,
 						},
 					},

--- a/internal/provider/model_sdwan_cisco_vpn_interface_feature_template.go
+++ b/internal/provider/model_sdwan_cisco_vpn_interface_feature_template.go
@@ -370,7 +370,7 @@ type CiscoVPNInterfaceIpv6Vrrps struct {
 	TrackOmpVariable        types.String                             `tfsdk:"track_omp_variable"`
 	TrackPrefixList         types.String                             `tfsdk:"track_prefix_list"`
 	TrackPrefixListVariable types.String                             `tfsdk:"track_prefix_list_variable"`
-	Ipv6Adresses            []CiscoVPNInterfaceIpv6VrrpsIpv6Adresses `tfsdk:"ipv6_adresses"`
+	Ipv6Addresses            []CiscoVPNInterfaceIpv6VrrpsIpv6Addresses `tfsdk:"ipv6_addresses"`
 }
 
 type CiscoVPNInterfaceIpv4VrrpsIpv4SecondaryAddresses struct {
@@ -388,7 +388,7 @@ type CiscoVPNInterfaceIpv4VrrpsTrackingObjects struct {
 	DecrementValueVariable types.String `tfsdk:"decrement_value_variable"`
 }
 
-type CiscoVPNInterfaceIpv6VrrpsIpv6Adresses struct {
+type CiscoVPNInterfaceIpv6VrrpsIpv6Addresses struct {
 	Optional              types.Bool   `tfsdk:"optional"`
 	Ipv6LinkLocal         types.String `tfsdk:"ipv6_link_local"`
 	Ipv6LinkLocalVariable types.String `tfsdk:"ipv6_link_local_variable"`
@@ -2376,7 +2376,7 @@ func (data CiscoVPNInterface) toBody(ctx context.Context) string {
 			itemBody, _ = sjson.Set(itemBody, "track-prefix-list."+"vipValue", item.TrackPrefixList.ValueString())
 		}
 		itemAttributes = append(itemAttributes, "ipv6")
-		if len(item.Ipv6Adresses) > 0 {
+		if len(item.Ipv6Addresses) > 0 {
 			itemBody, _ = sjson.Set(itemBody, "ipv6."+"vipObjectType", "tree")
 			itemBody, _ = sjson.Set(itemBody, "ipv6."+"vipType", "constant")
 			itemBody, _ = sjson.Set(itemBody, "ipv6."+"vipPrimaryKey", []string{"ipv6-link-local"})
@@ -2387,7 +2387,7 @@ func (data CiscoVPNInterface) toBody(ctx context.Context) string {
 			itemBody, _ = sjson.Set(itemBody, "ipv6."+"vipPrimaryKey", []string{"ipv6-link-local"})
 			itemBody, _ = sjson.Set(itemBody, "ipv6."+"vipValue", []interface{}{})
 		}
-		for _, childItem := range item.Ipv6Adresses {
+		for _, childItem := range item.Ipv6Addresses {
 			itemChildBody := ""
 			itemChildAttributes := make([]string, 0)
 			itemChildAttributes = append(itemChildAttributes, "ipv6-link-local")
@@ -5327,9 +5327,9 @@ func (data *CiscoVPNInterface) fromBody(ctx context.Context, res gjson.Result) {
 				item.TrackPrefixListVariable = types.StringNull()
 			}
 			if cValue := v.Get("ipv6.vipValue"); len(cValue.Array()) > 0 {
-				item.Ipv6Adresses = make([]CiscoVPNInterfaceIpv6VrrpsIpv6Adresses, 0)
+				item.Ipv6Addresses = make([]CiscoVPNInterfaceIpv6VrrpsIpv6Addresses, 0)
 				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := CiscoVPNInterfaceIpv6VrrpsIpv6Adresses{}
+					cItem := CiscoVPNInterfaceIpv6VrrpsIpv6Addresses{}
 					if ccValue := cv.Get("vipOptional"); ccValue.Exists() {
 						cItem.Optional = types.BoolValue(ccValue.Bool())
 					} else {
@@ -5373,7 +5373,7 @@ func (data *CiscoVPNInterface) fromBody(ctx context.Context, res gjson.Result) {
 						cItem.Prefix = types.StringNull()
 						cItem.PrefixVariable = types.StringNull()
 					}
-					item.Ipv6Adresses = append(item.Ipv6Adresses, cItem)
+					item.Ipv6Addresses = append(item.Ipv6Addresses, cItem)
 					return true
 				})
 			}
@@ -5989,14 +5989,14 @@ func (data *CiscoVPNInterface) hasChanges(ctx context.Context, state *CiscoVPNIn
 			if !data.Ipv6Vrrps[i].TrackPrefixList.Equal(state.Ipv6Vrrps[i].TrackPrefixList) {
 				hasChanges = true
 			}
-			if len(data.Ipv6Vrrps[i].Ipv6Adresses) != len(state.Ipv6Vrrps[i].Ipv6Adresses) {
+			if len(data.Ipv6Vrrps[i].Ipv6Addresses) != len(state.Ipv6Vrrps[i].Ipv6Addresses) {
 				hasChanges = true
 			} else {
-				for ii := range data.Ipv6Vrrps[i].Ipv6Adresses {
-					if !data.Ipv6Vrrps[i].Ipv6Adresses[ii].Ipv6LinkLocal.Equal(state.Ipv6Vrrps[i].Ipv6Adresses[ii].Ipv6LinkLocal) {
+				for ii := range data.Ipv6Vrrps[i].Ipv6Addresses {
+					if !data.Ipv6Vrrps[i].Ipv6Addresses[ii].Ipv6LinkLocal.Equal(state.Ipv6Vrrps[i].Ipv6Addresses[ii].Ipv6LinkLocal) {
 						hasChanges = true
 					}
-					if !data.Ipv6Vrrps[i].Ipv6Adresses[ii].Prefix.Equal(state.Ipv6Vrrps[i].Ipv6Adresses[ii].Prefix) {
+					if !data.Ipv6Vrrps[i].Ipv6Addresses[ii].Prefix.Equal(state.Ipv6Vrrps[i].Ipv6Addresses[ii].Prefix) {
 						hasChanges = true
 					}
 				}

--- a/internal/provider/resource_sdwan_centralized_policy.go
+++ b/internal/provider/resource_sdwan_centralized_policy.go
@@ -94,7 +94,7 @@ func (r *CentralizedPolicyResource) Schema(ctx context.Context, req resource.Sch
 							Optional:            true,
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Policy definiton type").AddStringEnumDescription("hubAndSpoke", "mesh", "control", "vpnMembershipGroup", "appRoute", "cflowd", "data").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Policy definition type").AddStringEnumDescription("hubAndSpoke", "mesh", "control", "vpnMembershipGroup", "appRoute", "cflowd", "data").String,
 							Required:            true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("hubAndSpoke", "mesh", "control", "vpnMembershipGroup", "appRoute", "cflowd", "data"),

--- a/internal/provider/resource_sdwan_cisco_vpn_interface_feature_template.go
+++ b/internal/provider/resource_sdwan_cisco_vpn_interface_feature_template.go
@@ -1549,7 +1549,7 @@ func (r *CiscoVPNInterfaceFeatureTemplateResource) Schema(ctx context.Context, r
 							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 							Optional:            true,
 						},
-						"ipv6_adresses": schema.ListNestedAttribute{
+						"ipv6_addresses": schema.ListNestedAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("IPv6 VRRP").String,
 							Optional:            true,
 							NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/resource_sdwan_cisco_vpn_interface_feature_template_test.go
+++ b/internal/provider/resource_sdwan_cisco_vpn_interface_feature_template_test.go
@@ -189,8 +189,8 @@ func TestAccSdwanCiscoVPNInterfaceFeatureTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.timer", "100"),
 					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.track_omp", "false"),
 					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.track_prefix_list", "PL1"),
-					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_adresses.0.ipv6_link_local", "fe80::260:8ff:fe52:f9d8"),
-					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_adresses.0.prefix", "2001:9::/48"),
+					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_addresses.0.ipv6_link_local", "fe80::260:8ff:fe52:f9d8"),
+					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "ipv6_vrrps.0.ipv6_addresses.0.prefix", "2001:9::/48"),
 					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "propagate_sgt", "false"),
 					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "static_sgt", "1003"),
 					resource.TestCheckResourceAttr("sdwan_cisco_vpn_interface_feature_template.test", "static_sgt_trusted", "false"),
@@ -401,7 +401,7 @@ func testAccSdwanCiscoVPNInterfaceFeatureTemplateConfig_all() string {
 			timer = 100
 			track_omp = false
 			track_prefix_list = "PL1"
-			ipv6_adresses = [{
+			ipv6_addresses = [{
 				ipv6_link_local = "fe80::260:8ff:fe52:f9d8"
 				prefix = "2001:9::/48"
 			}]

--- a/internal/provider/resource_sdwan_localized_policy.go
+++ b/internal/provider/resource_sdwan_localized_policy.go
@@ -82,25 +82,25 @@ func (r *LocalizedPolicyResource) Schema(ctx context.Context, req resource.Schem
 				Required:            true,
 			},
 			"flow_visibility_ipv4": schema.BoolAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("IPv4 flow visibilty").AddDefaultValueDescription("true").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IPv4 flow visibility").AddDefaultValueDescription("true").String,
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
 			},
 			"flow_visibility_ipv6": schema.BoolAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("IPv6 flow visibilty").AddDefaultValueDescription("true").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IPv6 flow visibility").AddDefaultValueDescription("true").String,
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
 			},
 			"application_visibility_ipv4": schema.BoolAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("IPv4 application visibilty").AddDefaultValueDescription("true").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IPv4 application visibility").AddDefaultValueDescription("true").String,
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
 			},
 			"application_visibility_ipv6": schema.BoolAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("IPv6 application visibilty").AddDefaultValueDescription("true").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IPv6 application visibility").AddDefaultValueDescription("true").String,
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
@@ -158,7 +158,7 @@ func (r *LocalizedPolicyResource) Schema(ctx context.Context, req resource.Schem
 							Optional:            true,
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Policy definiton type").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Policy definition type").String,
 							Required:            true,
 						},
 					},


### PR DESCRIPTION
This PR does two key things,

* Fixes some trivial typos in some descriptions
* Fixes a typo in some of the structs which form the basis for inputs for IPv6 addresses

Happy to dialog on this, as it may infer implications to clients using the provider, but figured it was something that likely should be fixed and semver major bumped?

Happy to separate out this potentially breaking change from the less-impacting description changes if that helps.

I'm unable to fully test this locally lacking access to an SD-WAN instance; filling in the required env vars with fake values doesn't let the test suite complete.