### PR TITLE
Add backticks around environment variable names

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,8 @@ provider "sdwan" {
 
 ### Optional
 
-- `insecure` (Boolean) Allow insecure HTTPS client. This can also be set as the SDWAN_INSECURE environment variable. Defaults to `true`.
-- `password` (String, Sensitive) Password for the SD-WAN Manager account. This can also be set as the SDWAN_PASSWORD environment variable.
-- `retries` (Number) Number of retries for REST API calls. This can also be set as the SDWAN_RETRIES environment variable. Defaults to `3`.
-- `url` (String) URL of the Cisco SD-WAN Manager device. This can also be set as the SDWAN_URL environment variable.
-- `username` (String) Username for the SD-WAN Manager account. This can also be set as the SDWAN_USERNAME environment variable.
+- `insecure` (Boolean) Allow insecure HTTPS client. This can also be set as the `SDWAN_INSECURE` environment variable. Defaults to `true`.
+- `password` (String, Sensitive) Password for the SD-WAN Manager account. This can also be set as the `SDWAN_PASSWORD` environment variable.
+- `retries` (Number) Number of retries for REST API calls. This can also be set as the `SDWAN_RETRIES` environment variable. Defaults to `3`.
+- `url` (String) URL of the Cisco SD-WAN Manager device. This can also be set as the `SDWAN_URL` environment variable.
+- `username` (String) Username for the SD-WAN Manager account. This can also be set as the `SDWAN_USERNAME` environment variable.

--- a/gen/templates/provider.go
+++ b/gen/templates/provider.go
@@ -69,24 +69,24 @@ func (p *SdwanProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"username": schema.StringAttribute{
-				MarkdownDescription: "Username for the SD-WAN Manager account. This can also be set as the SDWAN_USERNAME environment variable.",
+				MarkdownDescription: "Username for the SD-WAN Manager account. This can also be set as the `SDWAN_USERNAME` environment variable.",
 				Optional:            true,
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "Password for the SD-WAN Manager account. This can also be set as the SDWAN_PASSWORD environment variable.",
+				MarkdownDescription: "Password for the SD-WAN Manager account. This can also be set as the `SDWAN_PASSWORD` environment variable.",
 				Optional:            true,
 				Sensitive:           true,
 			},
 			"url": schema.StringAttribute{
-				MarkdownDescription: "URL of the Cisco SD-WAN Manager device. This can also be set as the SDWAN_URL environment variable.",
+				MarkdownDescription: "URL of the Cisco SD-WAN Manager device. This can also be set as the `SDWAN_URL` environment variable.",
 				Optional:            true,
 			},
 			"insecure": schema.BoolAttribute{
-				MarkdownDescription: "Allow insecure HTTPS client. This can also be set as the SDWAN_INSECURE environment variable. Defaults to `true`.",
+				MarkdownDescription: "Allow insecure HTTPS client. This can also be set as the `SDWAN_INSECURE` environment variable. Defaults to `true`.",
 				Optional:            true,
 			},
 			"retries": schema.Int64Attribute{
-				MarkdownDescription: "Number of retries for REST API calls. This can also be set as the SDWAN_RETRIES environment variable. Defaults to `3`.",
+				MarkdownDescription: "Number of retries for REST API calls. This can also be set as the `SDWAN_RETRIES` environment variable. Defaults to `3`.",
 				Optional:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(0, 9),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,24 +67,24 @@ func (p *SdwanProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"username": schema.StringAttribute{
-				MarkdownDescription: "Username for the SD-WAN Manager account. This can also be set as the SDWAN_USERNAME environment variable.",
+				MarkdownDescription: "Username for the SD-WAN Manager account. This can also be set as the `SDWAN_USERNAME` environment variable.",
 				Optional:            true,
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "Password for the SD-WAN Manager account. This can also be set as the SDWAN_PASSWORD environment variable.",
+				MarkdownDescription: "Password for the SD-WAN Manager account. This can also be set as the `SDWAN_PASSWORD` environment variable.",
 				Optional:            true,
 				Sensitive:           true,
 			},
 			"url": schema.StringAttribute{
-				MarkdownDescription: "URL of the Cisco SD-WAN Manager device. This can also be set as the SDWAN_URL environment variable.",
+				MarkdownDescription: "URL of the Cisco SD-WAN Manager device. This can also be set as the `SDWAN_URL` environment variable.",
 				Optional:            true,
 			},
 			"insecure": schema.BoolAttribute{
-				MarkdownDescription: "Allow insecure HTTPS client. This can also be set as the SDWAN_INSECURE environment variable. Defaults to `true`.",
+				MarkdownDescription: "Allow insecure HTTPS client. This can also be set as the `SDWAN_INSECURE` environment variable. Defaults to `true`.",
 				Optional:            true,
 			},
 			"retries": schema.Int64Attribute{
-				MarkdownDescription: "Number of retries for REST API calls. This can also be set as the SDWAN_RETRIES environment variable. Defaults to `3`.",
+				MarkdownDescription: "Number of retries for REST API calls. This can also be set as the `SDWAN_RETRIES` environment variable. Defaults to `3`.",
 				Optional:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(0, 9),


### PR DESCRIPTION
The provider documentation doesn't highlight the environment variables for the provider block.  Added backticks to bring attention to the option which is standard within most providers.