### PR TITLE
[UX2.0] Resolve Import issue for List Parameters

### DIFF
--- a/gen/templates/profile_parcels/resource.go
+++ b/gen/templates/profile_parcels/resource.go
@@ -448,7 +448,12 @@ func (r *{{camelCase .Name}}ProfileParcelResource) Read(ctx context.Context, req
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	{{- if not .FullUpdate}}
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	{{- range .Attributes}}{{- if .Reference}}
+	stateCopy.{{toGoName .TfName}} = types.StringNull()
+	{{- end}}{{- end}}
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_application_priority_qos_policy.go
+++ b/internal/provider/resource_sdwan_application_priority_qos_policy.go
@@ -200,7 +200,10 @@ func (r *ApplicationPriorityQoSProfileParcelResource) Read(ctx context.Context, 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_application_priority_traffic_policy_policy.go
+++ b/internal/provider/resource_sdwan_application_priority_traffic_policy_policy.go
@@ -694,7 +694,10 @@ func (r *ApplicationPriorityTrafficPolicyProfileParcelResource) Read(ctx context
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_other_thousandeyes_feature.go
+++ b/internal/provider/resource_sdwan_other_thousandeyes_feature.go
@@ -273,7 +273,10 @@ func (r *OtherThousandEyesProfileParcelResource) Read(ctx context.Context, req r
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_other_ucse_feature.go
+++ b/internal/provider/resource_sdwan_other_ucse_feature.go
@@ -267,7 +267,10 @@ func (r *OtherUCSEProfileParcelResource) Read(ctx context.Context, req resource.
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_dhcp_server_feature.go
+++ b/internal/provider/resource_sdwan_service_dhcp_server_feature.go
@@ -323,7 +323,10 @@ func (r *ServiceDHCPServerProfileParcelResource) Read(ctx context.Context, req r
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_ipv4_acl_feature.go
+++ b/internal/provider/resource_sdwan_service_ipv4_acl_feature.go
@@ -346,7 +346,10 @@ func (r *ServiceIPv4ACLProfileParcelResource) Read(ctx context.Context, req reso
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_ipv6_acl_feature.go
+++ b/internal/provider/resource_sdwan_service_ipv6_acl_feature.go
@@ -340,7 +340,10 @@ func (r *ServiceIPv6ACLProfileParcelResource) Read(ctx context.Context, req reso
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_lan_vpn_feature.go
+++ b/internal/provider/resource_sdwan_service_lan_vpn_feature.go
@@ -1185,7 +1185,10 @@ func (r *ServiceLANVPNProfileParcelResource) Read(ctx context.Context, req resou
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_lan_vpn_interface_ethernet_feature.go
+++ b/internal/provider/resource_sdwan_service_lan_vpn_interface_ethernet_feature.go
@@ -905,7 +905,11 @@ func (r *ServiceLANVPNInterfaceEthernetProfileParcelResource) Read(ctx context.C
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.ServiceLanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_lan_vpn_interface_gre_feature.go
+++ b/internal/provider/resource_sdwan_service_lan_vpn_interface_gre_feature.go
@@ -305,7 +305,11 @@ func (r *ServiceLANVPNInterfaceGREProfileParcelResource) Read(ctx context.Contex
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.ServiceLanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_lan_vpn_interface_ipsec_feature.go
+++ b/internal/provider/resource_sdwan_service_lan_vpn_interface_ipsec_feature.go
@@ -475,7 +475,11 @@ func (r *ServiceLANVPNInterfaceIPSecProfileParcelResource) Read(ctx context.Cont
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.ServiceLanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_lan_vpn_interface_svi_feature.go
+++ b/internal/provider/resource_sdwan_service_lan_vpn_interface_svi_feature.go
@@ -669,7 +669,11 @@ func (r *ServiceLANVPNInterfaceSVIProfileParcelResource) Read(ctx context.Contex
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.ServiceLanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_multicast_feature.go
+++ b/internal/provider/resource_sdwan_service_multicast_feature.go
@@ -652,7 +652,10 @@ func (r *ServiceMulticastProfileParcelResource) Read(ctx context.Context, req re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_object_tracker_feature.go
+++ b/internal/provider/resource_sdwan_service_object_tracker_feature.go
@@ -218,7 +218,10 @@ func (r *ServiceObjectTrackerProfileParcelResource) Read(ctx context.Context, re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_object_tracker_group_feature.go
+++ b/internal/provider/resource_sdwan_service_object_tracker_group_feature.go
@@ -198,7 +198,10 @@ func (r *ServiceObjectTrackerGroupProfileParcelResource) Read(ctx context.Contex
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_route_policy_feature.go
+++ b/internal/provider/resource_sdwan_service_route_policy_feature.go
@@ -394,7 +394,10 @@ func (r *ServiceRoutePolicyProfileParcelResource) Read(ctx context.Context, req 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_routing_bgp_feature.go
+++ b/internal/provider/resource_sdwan_service_routing_bgp_feature.go
@@ -960,7 +960,10 @@ func (r *ServiceRoutingBGPProfileParcelResource) Read(ctx context.Context, req r
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_routing_eigrp_feature.go
+++ b/internal/provider/resource_sdwan_service_routing_eigrp_feature.go
@@ -364,7 +364,10 @@ func (r *ServiceRoutingEIGRPProfileParcelResource) Read(ctx context.Context, req
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_routing_ospf_feature.go
+++ b/internal/provider/resource_sdwan_service_routing_ospf_feature.go
@@ -559,7 +559,10 @@ func (r *ServiceRoutingOSPFProfileParcelResource) Read(ctx context.Context, req 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_routing_ospfv3_ipv4_feature.go
+++ b/internal/provider/resource_sdwan_service_routing_ospfv3_ipv4_feature.go
@@ -560,7 +560,10 @@ func (r *ServiceRoutingOSPFv3IPv4ProfileParcelResource) Read(ctx context.Context
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_routing_ospfv3_ipv6_feature.go
+++ b/internal/provider/resource_sdwan_service_routing_ospfv3_ipv6_feature.go
@@ -544,7 +544,10 @@ func (r *ServiceRoutingOSPFv3IPv6ProfileParcelResource) Read(ctx context.Context
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_switchport_feature.go
+++ b/internal/provider/resource_sdwan_service_switchport_feature.go
@@ -424,7 +424,10 @@ func (r *ServiceSwitchportProfileParcelResource) Read(ctx context.Context, req r
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_tracker_feature.go
+++ b/internal/provider/resource_sdwan_service_tracker_feature.go
@@ -280,7 +280,10 @@ func (r *ServiceTrackerProfileParcelResource) Read(ctx context.Context, req reso
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_tracker_group_feature.go
+++ b/internal/provider/resource_sdwan_service_tracker_group_feature.go
@@ -186,7 +186,10 @@ func (r *ServiceTrackerGroupProfileParcelResource) Read(ctx context.Context, req
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_service_wireless_lan_feature.go
+++ b/internal/provider/resource_sdwan_service_wireless_lan_feature.go
@@ -355,7 +355,10 @@ func (r *ServiceWirelessLANProfileParcelResource) Read(ctx context.Context, req 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_aaa_feature.go
+++ b/internal/provider/resource_sdwan_system_aaa_feature.go
@@ -558,7 +558,10 @@ func (r *SystemAAAProfileParcelResource) Read(ctx context.Context, req resource.
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_banner_feature.go
+++ b/internal/provider/resource_sdwan_system_banner_feature.go
@@ -181,7 +181,10 @@ func (r *SystemBannerProfileParcelResource) Read(ctx context.Context, req resour
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_basic_feature.go
+++ b/internal/provider/resource_sdwan_system_basic_feature.go
@@ -491,7 +491,10 @@ func (r *SystemBasicProfileParcelResource) Read(ctx context.Context, req resourc
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_bfd_feature.go
+++ b/internal/provider/resource_sdwan_system_bfd_feature.go
@@ -250,7 +250,10 @@ func (r *SystemBFDProfileParcelResource) Read(ctx context.Context, req resource.
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_flexible_port_speed_feature.go
+++ b/internal/provider/resource_sdwan_system_flexible_port_speed_feature.go
@@ -170,7 +170,10 @@ func (r *SystemFlexiblePortSpeedProfileParcelResource) Read(ctx context.Context,
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_global_feature.go
+++ b/internal/provider/resource_sdwan_system_global_feature.go
@@ -361,7 +361,10 @@ func (r *SystemGlobalProfileParcelResource) Read(ctx context.Context, req resour
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_ipv4_device_access_feature.go
+++ b/internal/provider/resource_sdwan_system_ipv4_device_access_feature.go
@@ -238,7 +238,10 @@ func (r *SystemIPv4DeviceAccessProfileParcelResource) Read(ctx context.Context, 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_ipv6_device_access_feature.go
+++ b/internal/provider/resource_sdwan_system_ipv6_device_access_feature.go
@@ -238,7 +238,10 @@ func (r *SystemIPv6DeviceAccessProfileParcelResource) Read(ctx context.Context, 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_logging_feature.go
+++ b/internal/provider/resource_sdwan_system_logging_feature.go
@@ -381,7 +381,10 @@ func (r *SystemLoggingProfileParcelResource) Read(ctx context.Context, req resou
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_mrf_feature.go
+++ b/internal/provider/resource_sdwan_system_mrf_feature.go
@@ -203,7 +203,10 @@ func (r *SystemMRFProfileParcelResource) Read(ctx context.Context, req resource.
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_ntp_feature.go
+++ b/internal/provider/resource_sdwan_system_ntp_feature.go
@@ -300,7 +300,10 @@ func (r *SystemNTPProfileParcelResource) Read(ctx context.Context, req resource.
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_omp_feature.go
+++ b/internal/provider/resource_sdwan_system_omp_feature.go
@@ -414,7 +414,10 @@ func (r *SystemOMPProfileParcelResource) Read(ctx context.Context, req resource.
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_performance_monitoring_feature.go
+++ b/internal/provider/resource_sdwan_system_performance_monitoring_feature.go
@@ -188,7 +188,10 @@ func (r *SystemPerformanceMonitoringProfileParcelResource) Read(ctx context.Cont
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_remote_access_feature.go
+++ b/internal/provider/resource_sdwan_system_remote_access_feature.go
@@ -359,7 +359,10 @@ func (r *SystemRemoteAccessProfileParcelResource) Read(ctx context.Context, req 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_security_feature.go
+++ b/internal/provider/resource_sdwan_system_security_feature.go
@@ -374,7 +374,10 @@ func (r *SystemSecurityProfileParcelResource) Read(ctx context.Context, req reso
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_system_snmp_feature.go
+++ b/internal/provider/resource_sdwan_system_snmp_feature.go
@@ -447,7 +447,10 @@ func (r *SystemSNMPProfileParcelResource) Read(ctx context.Context, req resource
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_cellular_controller_feature.go
+++ b/internal/provider/resource_sdwan_transport_cellular_controller_feature.go
@@ -206,7 +206,10 @@ func (r *TransportCellularControllerProfileParcelResource) Read(ctx context.Cont
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_cellular_profile_feature.go
+++ b/internal/provider/resource_sdwan_transport_cellular_profile_feature.go
@@ -229,7 +229,10 @@ func (r *TransportCellularProfileProfileParcelResource) Read(ctx context.Context
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_gps_feature.go
+++ b/internal/provider/resource_sdwan_transport_gps_feature.go
@@ -214,7 +214,10 @@ func (r *TransportGPSProfileParcelResource) Read(ctx context.Context, req resour
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_ipv4_acl_feature.go
+++ b/internal/provider/resource_sdwan_transport_ipv4_acl_feature.go
@@ -346,7 +346,10 @@ func (r *TransportIPv4ACLProfileParcelResource) Read(ctx context.Context, req re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_ipv6_acl_feature.go
+++ b/internal/provider/resource_sdwan_transport_ipv6_acl_feature.go
@@ -340,7 +340,10 @@ func (r *TransportIPv6ACLProfileParcelResource) Read(ctx context.Context, req re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_ipv6_tracker_feature.go
+++ b/internal/provider/resource_sdwan_transport_ipv6_tracker_feature.go
@@ -256,7 +256,10 @@ func (r *TransportIPv6TrackerProfileParcelResource) Read(ctx context.Context, re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_ipv6_tracker_group_feature.go
+++ b/internal/provider/resource_sdwan_transport_ipv6_tracker_group_feature.go
@@ -197,7 +197,10 @@ func (r *TransportIPv6TrackerGroupProfileParcelResource) Read(ctx context.Contex
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_management_vpn_feature.go
+++ b/internal/provider/resource_sdwan_transport_management_vpn_feature.go
@@ -372,7 +372,10 @@ func (r *TransportManagementVPNProfileParcelResource) Read(ctx context.Context, 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_management_vpn_interface_ethernet_feature.go
+++ b/internal/provider/resource_sdwan_transport_management_vpn_interface_ethernet_feature.go
@@ -448,7 +448,11 @@ func (r *TransportManagementVPNInterfaceEthernetProfileParcelResource) Read(ctx 
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.TransportManagementVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_route_policy_feature.go
+++ b/internal/provider/resource_sdwan_transport_route_policy_feature.go
@@ -394,7 +394,10 @@ func (r *TransportRoutePolicyProfileParcelResource) Read(ctx context.Context, re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_routing_bgp_feature.go
+++ b/internal/provider/resource_sdwan_transport_routing_bgp_feature.go
@@ -990,7 +990,10 @@ func (r *TransportRoutingBGPProfileParcelResource) Read(ctx context.Context, req
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_routing_ospf_feature.go
+++ b/internal/provider/resource_sdwan_transport_routing_ospf_feature.go
@@ -559,7 +559,10 @@ func (r *TransportRoutingOSPFProfileParcelResource) Read(ctx context.Context, re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_routing_ospfv3_ipv4_feature.go
+++ b/internal/provider/resource_sdwan_transport_routing_ospfv3_ipv4_feature.go
@@ -560,7 +560,10 @@ func (r *TransportRoutingOSPFv3IPv4ProfileParcelResource) Read(ctx context.Conte
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_routing_ospfv3_ipv6_feature.go
+++ b/internal/provider/resource_sdwan_transport_routing_ospfv3_ipv6_feature.go
@@ -544,7 +544,10 @@ func (r *TransportRoutingOSPFv3IPv6ProfileParcelResource) Read(ctx context.Conte
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_t1_e1_controller_feature.go
+++ b/internal/provider/resource_sdwan_transport_t1_e1_controller_feature.go
@@ -332,7 +332,10 @@ func (r *TransportT1E1ControllerProfileParcelResource) Read(ctx context.Context,
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_tracker_feature.go
+++ b/internal/provider/resource_sdwan_transport_tracker_feature.go
@@ -258,7 +258,10 @@ func (r *TransportTrackerProfileParcelResource) Read(ctx context.Context, req re
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_tracker_group_feature.go
+++ b/internal/provider/resource_sdwan_transport_tracker_group_feature.go
@@ -186,7 +186,10 @@ func (r *TransportTrackerGroupProfileParcelResource) Read(ctx context.Context, r
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_wan_vpn_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_feature.go
@@ -431,7 +431,10 @@ func (r *TransportWANVPNProfileParcelResource) Read(ctx context.Context, req res
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_wan_vpn_interface_cellular_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_interface_cellular_feature.go
@@ -825,7 +825,11 @@ func (r *TransportWANVPNInterfaceCellularProfileParcelResource) Read(ctx context
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.TransportWanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_wan_vpn_interface_ethernet_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_interface_ethernet_feature.go
@@ -1238,7 +1238,11 @@ func (r *TransportWANVPNInterfaceEthernetProfileParcelResource) Read(ctx context
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.TransportWanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_wan_vpn_interface_gre_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_interface_gre_feature.go
@@ -305,7 +305,11 @@ func (r *TransportWANVPNInterfaceGREProfileParcelResource) Read(ctx context.Cont
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.TransportWanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_wan_vpn_interface_ipsec_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_interface_ipsec_feature.go
@@ -475,7 +475,11 @@ func (r *TransportWANVPNInterfaceIPSECProfileParcelResource) Read(ctx context.Co
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.TransportWanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)

--- a/internal/provider/resource_sdwan_transport_wan_vpn_interface_t1_e1_serial_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_interface_t1_e1_serial_feature.go
@@ -691,7 +691,11 @@ func (r *TransportWANVPNInterfaceT1E1SerialProfileParcelResource) Read(ctx conte
 	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
-	if state.isNull(ctx, res) {
+	stateCopy := state
+	stateCopy.FeatureProfileId = types.StringNull()
+	stateCopy.TransportWanVpnFeatureId = types.StringNull()
+
+	if stateCopy.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
 		state.updateFromBody(ctx, res)


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Resolve Import issue for List Parameters - The original logic would check is the current state was null and if so would use `state.fromBody` to properly import the resource, however terraform automatically set resource ID during the import before this logic, meaning the state was never null and would attempt to import with `state.updateFromBody` result in the opened issue.

### Types of Changes
<!-- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Build/CI change
* [ ] Code quality improvement/refactoring/documentation (no functional changes)

### Checklist
<!-- Go over all of the following points, and put an x in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] My code follows the code style of this project
* [x] I have added tests to cover my changes
* [x] All new and existing tests pass locally