### PR TITLE
[UX2.0] Resolve Issue #420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1 (unreleased)
+
+- BREAKING CHANGE: Replaces `no_authentication` attribute of `sdwan_transport_cellular_profile_feature` with `requires_authentication`
+
 ## 0.6.0
 
 - Delete configuration group when an error is encountered during creation, [link](https://github.com/CiscoDevNet/terraform-provider-sdwan/issues/390)

--- a/docs/data-sources/transport_cellular_profile_feature.md
+++ b/docs/data-sources/transport_cellular_profile_feature.md
@@ -35,7 +35,6 @@ data "sdwan_transport_cellular_profile_feature" "example" {
 - `authentication_type_variable` (String) Variable name
 - `description` (String) The description of the Feature
 - `name` (String) The name of the Feature
-- `no_authentication` (String) No Authentication
 - `no_overwrite` (Boolean) No Overwrite
 - `no_overwrite_variable` (String) Variable name
 - `packet_data_network_type` (String) Set packet data network type
@@ -46,4 +45,5 @@ data "sdwan_transport_cellular_profile_feature" "example" {
 - `profile_password_variable` (String) Variable name
 - `profile_username` (String) Set the profile username
 - `profile_username_variable` (String) Variable name
+- `requires_authentication` (Boolean) Require authentication type
 - `version` (Number) The version of the Feature

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.6.1 (unreleased)
+
+- BREAKING CHANGE: Replaces `no_authentication` attribute of `sdwan_transport_cellular_profile_feature` with `requires_authentication`
+
 ## 0.6.0
 
 - Delete configuration group when an error is encountered during creation, [link](https://github.com/CiscoDevNet/terraform-provider-sdwan/issues/390)

--- a/docs/resources/service_routing_eigrp_feature.md
+++ b/docs/resources/service_routing_eigrp_feature.md
@@ -77,7 +77,7 @@ resource "sdwan_service_routing_eigrp_feature" "example" {
   - Default value: `5`
 - `hello_interval_variable` (String) Variable name
 - `hmac_authentication_key` (String) Set hmac-sha-256 authentication key, Attribute conditional on `authentication_type` being equal to `hmac-sha-256`
-- `hmac_authentication_key_variable` (String) Variable name
+- `hmac_authentication_key_variable` (String) Variable name, Attribute conditional on `authentication_type` being equal to `hmac-sha-256`
 - `hold_time` (Number) Set EIGRP hold time
   - Range: `0`-`65535`
   - Default value: `15`

--- a/docs/resources/service_wireless_lan_feature.md
+++ b/docs/resources/service_wireless_lan_feature.md
@@ -91,7 +91,7 @@ Optional:
   - Default value: `true`
 - `broadcast_ssid_variable` (String) Variable name
 - `passphrase` (String) Set passphrase, Attribute conditional on `security_type` being equal to `personal`
-- `passphrase_variable` (String) Variable name
+- `passphrase_variable` (String) Variable name, Attribute conditional on `security_type` being equal to `personal`
 - `qos_profile` (String) Select QoS profile
   - Choices: `platinum`, `gold`, `silver`, `bronze`
   - Default value: `silver`
@@ -101,13 +101,13 @@ Optional:
   - Default value: `all`
 - `radio_type_variable` (String) Variable name
 - `radius_server_ip` (String) Set RADIUS server IP, Attribute conditional on `security_type` being equal to `enterprise`
-- `radius_server_ip_variable` (String) Variable name
+- `radius_server_ip_variable` (String) Variable name, Attribute conditional on `security_type` being equal to `enterprise`
 - `radius_server_port` (Number) Set RADIUS server authentication port, Attribute conditional on `security_type` being equal to `enterprise`
   - Range: `1`-`65535`
   - Default value: `1812`
-- `radius_server_port_variable` (String) Variable name
+- `radius_server_port_variable` (String) Variable name, Attribute conditional on `security_type` being equal to `enterprise`
 - `radius_server_secret` (String) Set RADIUS server shared secret, Attribute conditional on `security_type` being equal to `enterprise`
-- `radius_server_secret_variable` (String) Variable name
+- `radius_server_secret_variable` (String) Variable name, Attribute conditional on `security_type` being equal to `enterprise`
 - `security_type` (String) Select security type
   - Choices: `enterprise`, `personal`, `open`
 - `ssid_name` (String) Configure wlan SSID

--- a/docs/resources/system_remote_access_feature.md
+++ b/docs/resources/system_remote_access_feature.md
@@ -49,9 +49,9 @@ resource "sdwan_system_remote_access_feature" "example" {
 ### Optional
 
 - `aaa_derive_name_from_peer_domain` (String) , Attribute conditional on `connection_type_ssl` being equal to `false`
-- `aaa_derive_name_from_peer_domain_variable` (String) Variable name
+- `aaa_derive_name_from_peer_domain_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `aaa_derive_name_from_peer_identity` (String) , Attribute conditional on `connection_type_ssl` being equal to `false`
-- `aaa_derive_name_from_peer_identity_variable` (String) Variable name
+- `aaa_derive_name_from_peer_identity_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `aaa_enable_accounting` (Boolean) Enable Accounting
   - Default value: `true`
 - `aaa_enable_accounting_variable` (String) Variable name
@@ -70,29 +70,29 @@ resource "sdwan_system_remote_access_feature" "example" {
 - `ikev2_anti_dos_threshold` (Number) Anti-DOS Threshold, Attribute conditional on `connection_type_ssl` being equal to `false`
   - Range: `10`-`1000`
   - Default value: `100`
-- `ikev2_anti_dos_threshold_variable` (String) Variable name
+- `ikev2_anti_dos_threshold_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `ikev2_local_ike_identity_type` (String) , Attribute conditional on `connection_type_ssl` being equal to `false`
   - Choices: `EMAIL`, `FQDN`, `KEYID`, `IPv4 ADDRESS`, `IPv6 ADDRESS`
-- `ikev2_local_ike_identity_type_variable` (String) Variable name
+- `ikev2_local_ike_identity_type_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `ikev2_local_ike_identity_value` (String) , Attribute conditional on `connection_type_ssl` being equal to `false`
-- `ikev2_local_ike_identity_value_variable` (String) Variable name
+- `ikev2_local_ike_identity_value_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `ikev2_security_association_lifetime` (Number) Security Association Lifetime in Seconds, Attribute conditional on `connection_type_ssl` being equal to `false`
   - Range: `3600`-`86400`
   - Default value: `86400`
-- `ikev2_security_association_lifetime_variable` (String) Variable name
+- `ikev2_security_association_lifetime_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `ipsec_anti_replay_window_size` (Number) security Association Lifetime, Attribute conditional on `ipsec_enable_anti_replay` being equal to `true`
   - Default value: `64`
-- `ipsec_anti_replay_window_size_variable` (String) Variable name
+- `ipsec_anti_replay_window_size_variable` (String) Variable name, Attribute conditional on `ipsec_enable_anti_replay` being equal to `true`
 - `ipsec_enable_anti_replay` (Boolean) Enable Anti-Replay, Attribute conditional on `connection_type_ssl` being equal to `false`
   - Default value: `true`
-- `ipsec_enable_anti_replay_variable` (String) Variable name
+- `ipsec_enable_anti_replay_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `ipsec_enable_perfect_foward_secrecy` (Boolean) security Association Lifetime, Attribute conditional on `connection_type_ssl` being equal to `false`
   - Default value: `false`
-- `ipsec_enable_perfect_foward_secrecy_variable` (String) Variable name
+- `ipsec_enable_perfect_foward_secrecy_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `ipsec_security_association_lifetime` (Number) Security Association Lifetime in Seconds, Attribute conditional on `connection_type_ssl` being equal to `false`
   - Range: `3600`-`86400`
   - Default value: `3600`
-- `ipsec_security_association_lifetime_variable` (String) Variable name
+- `ipsec_security_association_lifetime_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `ipv4_pool_size` (Number) IPv4 Pool Size
   - Default value: `1000`
 - `ipv4_pool_size_variable` (String) Variable name
@@ -100,10 +100,10 @@ resource "sdwan_system_remote_access_feature" "example" {
   - Default value: `1024`
 - `ipv6_pool_size_variable` (String) Variable name
 - `psk_authentication_pre_shared_key` (String) PSK Pre Shared Key, Attribute conditional on `psk_authentication_type` being equal to `group`
-- `psk_authentication_pre_shared_key_variable` (String) Variable name
+- `psk_authentication_pre_shared_key_variable` (String) Variable name, Attribute conditional on `psk_authentication_type` being equal to `group`
 - `psk_authentication_type` (String) PSK Selection, Attribute conditional on `connection_type_ssl` being equal to `false`
   - Choices: `aaa`, `group`
-- `psk_authentication_type_variable` (String) Variable name
+- `psk_authentication_type_variable` (String) Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`
 - `radius_group_name_variable` (String) Variable name
 
 ### Read-Only

--- a/docs/resources/transport_cellular_profile_feature.md
+++ b/docs/resources/transport_cellular_profile_feature.md
@@ -44,7 +44,7 @@ resource "sdwan_transport_cellular_profile_feature" "example" {
 - `access_point_name_variable` (String) Variable name
 - `authentication_type` (String) Set authentication type, Attribute conditional on `requires_authentication` being equal to `true`
   - Choices: `pap`, `chap`, `pap_chap`
-- `authentication_type_variable` (String) Variable name
+- `authentication_type_variable` (String) Variable name, Attribute conditional on `requires_authentication` being equal to `true`
 - `description` (String) The description of the Feature
 - `no_overwrite` (Boolean) No Overwrite
 - `no_overwrite_variable` (String) Variable name
@@ -56,9 +56,9 @@ resource "sdwan_transport_cellular_profile_feature" "example" {
   - Range: `1`-`16`
 - `profile_id_variable` (String) Variable name
 - `profile_password` (String) Set the profile password, Attribute conditional on `requires_authentication` being equal to `true`
-- `profile_password_variable` (String) Variable name
+- `profile_password_variable` (String) Variable name, Attribute conditional on `requires_authentication` being equal to `true`
 - `profile_username` (String) Set the profile username, Attribute conditional on `requires_authentication` being equal to `true`
-- `profile_username_variable` (String) Variable name
+- `profile_username_variable` (String) Variable name, Attribute conditional on `requires_authentication` being equal to `true`
 - `requires_authentication` (Boolean) Require authentication type
   - Default value: `false`
 

--- a/docs/resources/transport_cellular_profile_feature.md
+++ b/docs/resources/transport_cellular_profile_feature.md
@@ -21,6 +21,7 @@ resource "sdwan_transport_cellular_profile_feature" "example" {
   feature_profile_id       = "f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac"
   profile_id               = 1
   access_point_name        = "apn1"
+  requires_authentication  = true
   authentication_type      = "pap"
   profile_username         = "example"
   profile_password         = "example123!"
@@ -41,11 +42,10 @@ resource "sdwan_transport_cellular_profile_feature" "example" {
 
 - `access_point_name` (String) Set access point name
 - `access_point_name_variable` (String) Variable name
-- `authentication_type` (String) Set authentication type
+- `authentication_type` (String) Set authentication type, Attribute conditional on `requires_authentication` being equal to `true`
   - Choices: `pap`, `chap`, `pap_chap`
 - `authentication_type_variable` (String) Variable name
 - `description` (String) The description of the Feature
-- `no_authentication` (String) No Authentication
 - `no_overwrite` (Boolean) No Overwrite
 - `no_overwrite_variable` (String) Variable name
 - `packet_data_network_type` (String) Set packet data network type
@@ -55,10 +55,12 @@ resource "sdwan_transport_cellular_profile_feature" "example" {
 - `profile_id` (Number) Set Profile ID
   - Range: `1`-`16`
 - `profile_id_variable` (String) Variable name
-- `profile_password` (String) Set the profile password
+- `profile_password` (String) Set the profile password, Attribute conditional on `requires_authentication` being equal to `true`
 - `profile_password_variable` (String) Variable name
-- `profile_username` (String) Set the profile username
+- `profile_username` (String) Set the profile username, Attribute conditional on `requires_authentication` being equal to `true`
 - `profile_username_variable` (String) Variable name
+- `requires_authentication` (Boolean) Require authentication type
+  - Default value: `false`
 
 ### Read-Only
 

--- a/docs/resources/transport_management_vpn_feature.md
+++ b/docs/resources/transport_management_vpn_feature.md
@@ -96,7 +96,7 @@ Optional:
 - `administrative_distance` (Number) Administrative distance, Attribute conditional on `gateway` being equal to `null0`
   - Range: `1`-`255`
   - Default value: `1`
-- `administrative_distance_variable` (String) Variable name
+- `administrative_distance_variable` (String) Variable name, Attribute conditional on `gateway` being equal to `null0`
 - `gateway` (String) Gateway
   - Choices: `nextHop`, `dhcp`, `null0`
   - Default value: `nextHop`
@@ -130,7 +130,7 @@ Optional:
   - Choices: `nextHop`, `null0`, `nat`
 - `nat` (String) IPv6 Nat, Attribute conditional on `gateway` being equal to `nat`
   - Choices: `NAT64`, `NAT66`
-- `nat_variable` (String) Variable name
+- `nat_variable` (String) Variable name, Attribute conditional on `gateway` being equal to `nat`
 - `next_hops` (Attributes List) IPv6 Route Gateway Next Hop, Attribute conditional on `gateway` being equal to `nextHop` (see [below for nested schema](#nestedatt--ipv6_static_routes--next_hops))
 - `null0` (Boolean) IPv6 Route Gateway Next Hop, Attribute conditional on `gateway` being equal to `null0`
 - `prefix` (String) Prefix

--- a/docs/resources/transport_management_vpn_interface_ethernet_feature.md
+++ b/docs/resources/transport_management_vpn_interface_ethernet_feature.md
@@ -99,7 +99,7 @@ resource "sdwan_transport_management_vpn_interface_ethernet_feature" "example" {
   - Default value: `1500`
 - `ip_mtu_variable` (String) Variable name
 - `ipv4_address` (String) IP Address, Attribute conditional on `ipv4_configuration_type` being equal to `static`
-- `ipv4_address_variable` (String) Variable name
+- `ipv4_address_variable` (String) Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`
 - `ipv4_auto_detect_bandwidth` (Boolean) Interface auto detect bandwidth
   - Default value: `false`
 - `ipv4_auto_detect_bandwidth_variable` (String) Variable name
@@ -109,7 +109,7 @@ resource "sdwan_transport_management_vpn_interface_ethernet_feature" "example" {
 - `ipv4_dhcp_distance` (Number) DHCP Distance, Attribute conditional on `ipv4_configuration_type` being equal to `dynamic`
   - Range: `1`-`65536`
   - Default value: `1`
-- `ipv4_dhcp_distance_variable` (String) Variable name
+- `ipv4_dhcp_distance_variable` (String) Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `dynamic`
 - `ipv4_dhcp_helper` (Set of String) List of DHCP IPv4 helper addresses (min 1, max 8)
 - `ipv4_dhcp_helper_variable` (String) Variable name
 - `ipv4_iperf_server` (String) Iperf server for auto bandwidth detect
@@ -117,9 +117,9 @@ resource "sdwan_transport_management_vpn_interface_ethernet_feature" "example" {
 - `ipv4_secondary_addresses` (Attributes List) Secondary IpV4 Addresses, Attribute conditional on `ipv4_configuration_type` being equal to `static` (see [below for nested schema](#nestedatt--ipv4_secondary_addresses))
 - `ipv4_subnet_mask` (String) Subnet Mask, Attribute conditional on `ipv4_configuration_type` being equal to `static`
   - Choices: `255.255.255.255`, `255.255.255.254`, `255.255.255.252`, `255.255.255.248`, `255.255.255.240`, `255.255.255.224`, `255.255.255.192`, `255.255.255.128`, `255.255.255.0`, `255.255.254.0`, `255.255.252.0`, `255.255.248.0`, `255.255.240.0`, `255.255.224.0`, `255.255.192.0`, `255.255.128.0`, `255.255.0.0`, `255.254.0.0`, `255.252.0.0`, `255.240.0.0`, `255.224.0.0`, `255.192.0.0`, `255.128.0.0`, `255.0.0.0`, `254.0.0.0`, `252.0.0.0`, `248.0.0.0`, `240.0.0.0`, `224.0.0.0`, `192.0.0.0`, `128.0.0.0`, `0.0.0.0`
-- `ipv4_subnet_mask_variable` (String) Variable name
+- `ipv4_subnet_mask_variable` (String) Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`
 - `ipv6_address` (String) IPv6 Address Secondary, Attribute conditional on `ipv6_configuration_type` being equal to `static`
-- `ipv6_address_variable` (String) Variable name
+- `ipv6_address_variable` (String) Variable name, Attribute conditional on `ipv6_configuration_type` being equal to `static`
 - `ipv6_configuration_type` (String) IPv6 Configuration Type
   - Choices: `dynamic`, `static`, `none`
   - Default value: `none`

--- a/docs/resources/transport_t1_e1_controller_feature.md
+++ b/docs/resources/transport_t1_e1_controller_feature.md
@@ -86,10 +86,10 @@ Optional:
 - `e1_linecode_variable` (String) Variable name
 - `length_long` (String) length, Attribute conditional on `cable_length` being equal to `long`
   - Choices: `-15db`, `-22.5db`, `-7.5db`, `0db`
-- `length_long_variable` (String) Variable name
+- `length_long_variable` (String) Variable name, Attribute conditional on `cable_length` being equal to `long`
 - `length_short` (String) length, Attribute conditional on `cable_length` being equal to `short`
   - Choices: `110ft`, `220ft`, `330ft`, `440ft`, `550ft`, `660ft`
-- `length_short_variable` (String) Variable name
+- `length_short_variable` (String) Variable name, Attribute conditional on `cable_length` being equal to `short`
 - `line_mode` (String) Line Mode
   - Choices: `secondary`, `primary`
 - `line_mode_variable` (String) Variable name

--- a/docs/resources/transport_wan_vpn_feature.md
+++ b/docs/resources/transport_wan_vpn_feature.md
@@ -115,7 +115,7 @@ Optional:
 - `administrative_distance` (Number) Administrative distance, Attribute conditional on `gateway` being equal to `null0`
   - Range: `1`-`255`
   - Default value: `1`
-- `administrative_distance_variable` (String) Variable name
+- `administrative_distance_variable` (String) Variable name, Attribute conditional on `gateway` being equal to `null0`
 - `gateway` (String) Gateway
   - Choices: `nextHop`, `dhcp`, `null0`
   - Default value: `nextHop`
@@ -149,7 +149,7 @@ Optional:
   - Choices: `nextHop`, `null0`, `nat`
 - `nat` (String) IPv6 Nat, Attribute conditional on `gateway` being equal to `nat`
   - Choices: `NAT64`, `NAT66`
-- `nat_variable` (String) Variable name
+- `nat_variable` (String) Variable name, Attribute conditional on `gateway` being equal to `nat`
 - `next_hops` (Attributes List) IPv6 Route Gateway Next Hop, Attribute conditional on `gateway` being equal to `nextHop` (see [below for nested schema](#nestedatt--ipv6_static_routes--next_hops))
 - `null0` (Boolean) IPv6 Route Gateway Next Hop, Attribute conditional on `gateway` being equal to `null0`
 - `prefix` (String) Prefix

--- a/docs/resources/transport_wan_vpn_interface_ethernet_feature.md
+++ b/docs/resources/transport_wan_vpn_interface_ethernet_feature.md
@@ -197,22 +197,22 @@ resource "sdwan_transport_wan_vpn_interface_ethernet_feature" "example" {
 - `iperf_server` (String) Iperf server for auto bandwidth detect
 - `iperf_server_variable` (String) Variable name
 - `ipv4_address` (String) IP Address, Attribute conditional on `ipv4_configuration_type` being equal to `static`
-- `ipv4_address_variable` (String) Variable name
+- `ipv4_address_variable` (String) Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`
 - `ipv4_configuration_type` (String) IPv4 Configuration Type
   - Choices: `dynamic`, `static`
   - Default value: `dynamic`
 - `ipv4_dhcp_distance` (Number) DHCP Distance, Attribute conditional on `ipv4_configuration_type` being equal to `dynamic`
   - Range: `1`-`65536`
   - Default value: `1`
-- `ipv4_dhcp_distance_variable` (String) Variable name
+- `ipv4_dhcp_distance_variable` (String) Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `dynamic`
 - `ipv4_dhcp_helper` (Set of String) List of DHCP IPv4 helper addresses (min 1, max 8)
 - `ipv4_dhcp_helper_variable` (String) Variable name
 - `ipv4_secondary_addresses` (Attributes List) Secondary IpV4 Addresses, Attribute conditional on `ipv4_configuration_type` being equal to `static` (see [below for nested schema](#nestedatt--ipv4_secondary_addresses))
 - `ipv4_subnet_mask` (String) Subnet Mask, Attribute conditional on `ipv4_configuration_type` being equal to `static`
   - Choices: `255.255.255.255`, `255.255.255.254`, `255.255.255.252`, `255.255.255.248`, `255.255.255.240`, `255.255.255.224`, `255.255.255.192`, `255.255.255.128`, `255.255.255.0`, `255.255.254.0`, `255.255.252.0`, `255.255.248.0`, `255.255.240.0`, `255.255.224.0`, `255.255.192.0`, `255.255.128.0`, `255.255.0.0`, `255.254.0.0`, `255.252.0.0`, `255.240.0.0`, `255.224.0.0`, `255.192.0.0`, `255.128.0.0`, `255.0.0.0`, `254.0.0.0`, `252.0.0.0`, `248.0.0.0`, `240.0.0.0`, `224.0.0.0`, `192.0.0.0`, `128.0.0.0`, `0.0.0.0`
-- `ipv4_subnet_mask_variable` (String) Variable name
+- `ipv4_subnet_mask_variable` (String) Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`
 - `ipv6_address` (String) IPv6 Address Secondary, Attribute conditional on `ipv6_configuration_type` being equal to `static`
-- `ipv6_address_variable` (String) Variable name
+- `ipv6_address_variable` (String) Variable name, Attribute conditional on `ipv6_configuration_type` being equal to `static`
 - `ipv6_configuration_type` (String) IPv6 Configuration Type
   - Choices: `dynamic`, `static`, `none`
   - Default value: `none`

--- a/examples/resources/sdwan_transport_cellular_profile_feature/resource.tf
+++ b/examples/resources/sdwan_transport_cellular_profile_feature/resource.tf
@@ -4,6 +4,7 @@ resource "sdwan_transport_cellular_profile_feature" "example" {
   feature_profile_id       = "f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac"
   profile_id               = 1
   access_point_name        = "apn1"
+  requires_authentication  = true
   authentication_type      = "pap"
   profile_username         = "example"
   profile_password         = "example123!"

--- a/gen/definitions/profile_parcels/transport_cellular_profile.yaml
+++ b/gen/definitions/profile_parcels/transport_cellular_profile.yaml
@@ -25,27 +25,53 @@ attributes:
     tf_name: access_point_name
     data_path: [profileConfig, profileInfo]
     example: apn1
+  - tf_name: requires_authentication
+    type: Bool
+    tf_only: true
+    default_value: false
+    default_value_present: true
+    description: Require authentication type
+    example: true
+    minimum_test_value: 'true'
   - model_name: noAuthentication
     data_path: [profileConfig, profileInfo, authentication]
     type: String
     exclude_test: true
+    default_value: none
+    default_value_present: true
     example: none
+    conditional_attribute:
+      name: requires_authentication
+      value: false
+      type: Bool
   - model_name: type
     tf_name: authentication_type
     data_path: [profileConfig, profileInfo, authentication, needAuthentication]
     type: String
     example: pap
+    conditional_attribute:
+      name: requires_authentication
+      value: true
+      type: Bool
   - model_name: username
     tf_name: profile_username
     data_path: [profileConfig, profileInfo, authentication, needAuthentication]
     type: String
     example: example
+    conditional_attribute:
+      name: requires_authentication
+      value: true
+      type: Bool
   - model_name: password
     tf_name: profile_password
     data_path: [profileConfig, profileInfo, authentication, needAuthentication]
     type: String
     write_only: true
     example: example123!
+    conditional_attribute:
+      name: requires_authentication
+      value: true
+      type: Bool
   - model_name: pdnType
     tf_name: packet_data_network_type
     data_path: [profileConfig, profileInfo]

--- a/gen/templates/profile_parcels/resource.go
+++ b/gen/templates/profile_parcels/resource.go
@@ -336,7 +336,7 @@ func (r *{{camelCase .Name}}ProfileParcelResource) Schema(ctx context.Context, r
 												},
 												{{- if .Variable}}
 												"{{.TfName}}_variable": schema.StringAttribute{
-													MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+													MarkdownDescription: helpers.NewAttributeDescription("Variable name{{if .ConditionalAttribute.Name}}, Attribute conditional on `{{.ConditionalAttribute.Name}}` being equal to `{{.ConditionalAttribute.Value}}`{{end}}").String,
 													Optional:            true,
 												},
 												{{- end}}
@@ -348,7 +348,7 @@ func (r *{{camelCase .Name}}ProfileParcelResource) Schema(ctx context.Context, r
 									},
 									{{- if .Variable}}
 									"{{.TfName}}_variable": schema.StringAttribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name{{if .ConditionalAttribute.Name}}, Attribute conditional on `{{.ConditionalAttribute.Name}}` being equal to `{{.ConditionalAttribute.Value}}`{{end}}").String,
 										Optional:            true,
 									},
 									{{- end}}
@@ -360,7 +360,7 @@ func (r *{{camelCase .Name}}ProfileParcelResource) Schema(ctx context.Context, r
 						},
 						{{- if .Variable}}
 						"{{.TfName}}_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name{{if .ConditionalAttribute.Name}}, Attribute conditional on `{{.ConditionalAttribute.Name}}` being equal to `{{.ConditionalAttribute.Value}}`{{end}}").String,
 							Optional:            true,
 						},
 						{{- end}}
@@ -372,7 +372,7 @@ func (r *{{camelCase .Name}}ProfileParcelResource) Schema(ctx context.Context, r
 			},
 			{{- if .Variable}}
 			"{{.TfName}}_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name{{if .ConditionalAttribute.Name}}, Attribute conditional on `{{.ConditionalAttribute.Name}}` being equal to `{{.ConditionalAttribute.Value}}`{{end}}").String,
 				Optional:            true,
 			},
 			{{- end}}

--- a/internal/provider/data_source_sdwan_transport_cellular_profile_feature.go
+++ b/internal/provider/data_source_sdwan_transport_cellular_profile_feature.go
@@ -94,8 +94,8 @@ func (d *TransportCellularProfileProfileParcelDataSource) Schema(ctx context.Con
 				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 				Computed:            true,
 			},
-			"no_authentication": schema.StringAttribute{
-				MarkdownDescription: "No Authentication",
+			"requires_authentication": schema.BoolAttribute{
+				MarkdownDescription: "Require authentication type",
 				Computed:            true,
 			},
 			"authentication_type": schema.StringAttribute{

--- a/internal/provider/data_source_sdwan_transport_cellular_profile_feature_test.go
+++ b/internal/provider/data_source_sdwan_transport_cellular_profile_feature_test.go
@@ -71,6 +71,7 @@ func testAccDataSourceSdwanTransportCellularProfileProfileParcelConfig() string 
 	config += `	feature_profile_id = sdwan_transport_feature_profile.test.id` + "\n"
 	config += `	profile_id = 1` + "\n"
 	config += `	access_point_name = "apn1"` + "\n"
+	config += `	requires_authentication = true` + "\n"
 	config += `	authentication_type = "pap"` + "\n"
 	config += `	profile_username = "example"` + "\n"
 	config += `	profile_password = "example123!"` + "\n"

--- a/internal/provider/model_sdwan_transport_cellular_profile_feature.go
+++ b/internal/provider/model_sdwan_transport_cellular_profile_feature.go
@@ -41,7 +41,7 @@ type TransportCellularProfile struct {
 	ProfileIdVariable             types.String `tfsdk:"profile_id_variable"`
 	AccessPointName               types.String `tfsdk:"access_point_name"`
 	AccessPointNameVariable       types.String `tfsdk:"access_point_name_variable"`
-	NoAuthentication              types.String `tfsdk:"no_authentication"`
+	RequiresAuthentication        types.Bool   `tfsdk:"requires_authentication"`
 	AuthenticationType            types.String `tfsdk:"authentication_type"`
 	AuthenticationTypeVariable    types.String `tfsdk:"authentication_type_variable"`
 	ProfileUsername               types.String `tfsdk:"profile_username"`
@@ -104,44 +104,42 @@ func (data TransportCellularProfile) toBody(ctx context.Context) string {
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.apn.value", data.AccessPointName.ValueString())
 		}
 	}
-	if !data.NoAuthentication.IsNull() {
-		if true {
-			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.noAuthentication.optionType", "global")
-			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.noAuthentication.value", data.NoAuthentication.ValueString())
-		}
+	if true && data.RequiresAuthentication.ValueBool() == false {
+		body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.noAuthentication.optionType", "default")
+		body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.noAuthentication.value", "none")
 	}
 
 	if !data.AuthenticationTypeVariable.IsNull() {
-		if true {
+		if true && data.RequiresAuthentication.ValueBool() == true {
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.type.optionType", "variable")
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.type.value", data.AuthenticationTypeVariable.ValueString())
 		}
 	} else if !data.AuthenticationType.IsNull() {
-		if true {
+		if true && data.RequiresAuthentication.ValueBool() == true {
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.type.optionType", "global")
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.type.value", data.AuthenticationType.ValueString())
 		}
 	}
 
 	if !data.ProfileUsernameVariable.IsNull() {
-		if true {
+		if true && data.RequiresAuthentication.ValueBool() == true {
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.username.optionType", "variable")
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.username.value", data.ProfileUsernameVariable.ValueString())
 		}
 	} else if !data.ProfileUsername.IsNull() {
-		if true {
+		if true && data.RequiresAuthentication.ValueBool() == true {
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.username.optionType", "global")
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.username.value", data.ProfileUsername.ValueString())
 		}
 	}
 
 	if !data.ProfilePasswordVariable.IsNull() {
-		if true {
+		if true && data.RequiresAuthentication.ValueBool() == true {
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.password.optionType", "variable")
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.password.value", data.ProfilePasswordVariable.ValueString())
 		}
 	} else if !data.ProfilePassword.IsNull() {
-		if true {
+		if true && data.RequiresAuthentication.ValueBool() == true {
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.password.optionType", "global")
 			body, _ = sjson.Set(body, path+"profileConfig.profileInfo.authentication.needAuthentication.password.value", data.ProfilePassword.ValueString())
 		}
@@ -212,14 +210,6 @@ func (data *TransportCellularProfile) fromBody(ctx context.Context, res gjson.Re
 			data.AccessPointNameVariable = types.StringValue(va.String())
 		} else if t.String() == "global" {
 			data.AccessPointName = types.StringValue(va.String())
-		}
-	}
-	data.NoAuthentication = types.StringNull()
-
-	if t := res.Get(path + "profileConfig.profileInfo.authentication.noAuthentication.optionType"); t.Exists() {
-		va := res.Get(path + "profileConfig.profileInfo.authentication.noAuthentication.value")
-		if t.String() == "global" {
-			data.NoAuthentication = types.StringValue(va.String())
 		}
 	}
 	data.AuthenticationType = types.StringNull()
@@ -293,14 +283,6 @@ func (data *TransportCellularProfile) updateFromBody(ctx context.Context, res gj
 			data.AccessPointNameVariable = types.StringValue(va.String())
 		} else if t.String() == "global" {
 			data.AccessPointName = types.StringValue(va.String())
-		}
-	}
-	data.NoAuthentication = types.StringNull()
-
-	if t := res.Get(path + "profileConfig.profileInfo.authentication.noAuthentication.optionType"); t.Exists() {
-		va := res.Get(path + "profileConfig.profileInfo.authentication.noAuthentication.value")
-		if t.String() == "global" {
-			data.NoAuthentication = types.StringValue(va.String())
 		}
 	}
 	data.AuthenticationType = types.StringNull()

--- a/internal/provider/resource_sdwan_service_routing_eigrp_feature.go
+++ b/internal/provider/resource_sdwan_service_routing_eigrp_feature.go
@@ -190,7 +190,7 @@ func (r *ServiceRoutingEIGRPProfileParcelResource) Schema(ctx context.Context, r
 				},
 			},
 			"hmac_authentication_key_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `authentication_type` being equal to `hmac-sha-256`").String,
 				Optional:            true,
 			},
 			"md5_keys": schema.ListNestedAttribute{

--- a/internal/provider/resource_sdwan_service_wireless_lan_feature.go
+++ b/internal/provider/resource_sdwan_service_wireless_lan_feature.go
@@ -169,7 +169,7 @@ func (r *ServiceWirelessLANProfileParcelResource) Schema(ctx context.Context, re
 							Optional:            true,
 						},
 						"radius_server_ip_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `security_type` being equal to `enterprise`").String,
 							Optional:            true,
 						},
 						"radius_server_port": schema.Int64Attribute{
@@ -180,7 +180,7 @@ func (r *ServiceWirelessLANProfileParcelResource) Schema(ctx context.Context, re
 							},
 						},
 						"radius_server_port_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `security_type` being equal to `enterprise`").String,
 							Optional:            true,
 						},
 						"radius_server_secret": schema.StringAttribute{
@@ -191,7 +191,7 @@ func (r *ServiceWirelessLANProfileParcelResource) Schema(ctx context.Context, re
 							},
 						},
 						"radius_server_secret_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `security_type` being equal to `enterprise`").String,
 							Optional:            true,
 						},
 						"passphrase": schema.StringAttribute{
@@ -202,7 +202,7 @@ func (r *ServiceWirelessLANProfileParcelResource) Schema(ctx context.Context, re
 							},
 						},
 						"passphrase_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `security_type` being equal to `personal`").String,
 							Optional:            true,
 						},
 						"qos_profile": schema.StringAttribute{

--- a/internal/provider/resource_sdwan_system_remote_access_feature.go
+++ b/internal/provider/resource_sdwan_system_remote_access_feature.go
@@ -132,7 +132,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"psk_authentication_type_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"psk_authentication_pre_shared_key": schema.StringAttribute{
@@ -143,7 +143,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"psk_authentication_pre_shared_key_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `psk_authentication_type` being equal to `group`").String,
 				Optional:            true,
 			},
 			"radius_group_name": schema.StringAttribute{
@@ -187,7 +187,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"aaa_derive_name_from_peer_identity_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"aaa_derive_name_from_peer_domain": schema.StringAttribute{
@@ -198,7 +198,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"aaa_derive_name_from_peer_domain_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"aaa_enable_accounting": schema.BoolAttribute{
@@ -217,7 +217,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"ikev2_local_ike_identity_type_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"ikev2_local_ike_identity_value": schema.StringAttribute{
@@ -228,7 +228,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"ikev2_local_ike_identity_value_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"ikev2_security_association_lifetime": schema.Int64Attribute{
@@ -239,7 +239,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"ikev2_security_association_lifetime_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"ikev2_anti_dos_threshold": schema.Int64Attribute{
@@ -250,7 +250,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"ikev2_anti_dos_threshold_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"ipsec_enable_anti_replay": schema.BoolAttribute{
@@ -258,7 +258,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				Optional:            true,
 			},
 			"ipsec_enable_anti_replay_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"ipsec_anti_replay_window_size": schema.Int64Attribute{
@@ -266,7 +266,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				Optional:            true,
 			},
 			"ipsec_anti_replay_window_size_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipsec_enable_anti_replay` being equal to `true`").String,
 				Optional:            true,
 			},
 			"ipsec_security_association_lifetime": schema.Int64Attribute{
@@ -277,7 +277,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				},
 			},
 			"ipsec_security_association_lifetime_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 			"ipsec_enable_perfect_foward_secrecy": schema.BoolAttribute{
@@ -285,7 +285,7 @@ func (r *SystemRemoteAccessProfileParcelResource) Schema(ctx context.Context, re
 				Optional:            true,
 			},
 			"ipsec_enable_perfect_foward_secrecy_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `connection_type_ssl` being equal to `false`").String,
 				Optional:            true,
 			},
 		},

--- a/internal/provider/resource_sdwan_transport_cellular_profile_feature.go
+++ b/internal/provider/resource_sdwan_transport_cellular_profile_feature.go
@@ -108,12 +108,12 @@ func (r *TransportCellularProfileProfileParcelResource) Schema(ctx context.Conte
 				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 				Optional:            true,
 			},
-			"no_authentication": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("No Authentication").String,
+			"requires_authentication": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Require authentication type").AddDefaultValueDescription("false").String,
 				Optional:            true,
 			},
 			"authentication_type": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Set authentication type").AddStringEnumDescription("pap", "chap", "pap_chap").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Set authentication type, Attribute conditional on `requires_authentication` being equal to `true`").AddStringEnumDescription("pap", "chap", "pap_chap").String,
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("pap", "chap", "pap_chap"),
@@ -124,7 +124,7 @@ func (r *TransportCellularProfileProfileParcelResource) Schema(ctx context.Conte
 				Optional:            true,
 			},
 			"profile_username": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Set the profile username").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Set the profile username, Attribute conditional on `requires_authentication` being equal to `true`").String,
 				Optional:            true,
 			},
 			"profile_username_variable": schema.StringAttribute{
@@ -132,7 +132,7 @@ func (r *TransportCellularProfileProfileParcelResource) Schema(ctx context.Conte
 				Optional:            true,
 			},
 			"profile_password": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Set the profile password").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Set the profile password, Attribute conditional on `requires_authentication` being equal to `true`").String,
 				Optional:            true,
 			},
 			"profile_password_variable": schema.StringAttribute{

--- a/internal/provider/resource_sdwan_transport_cellular_profile_feature.go
+++ b/internal/provider/resource_sdwan_transport_cellular_profile_feature.go
@@ -120,7 +120,7 @@ func (r *TransportCellularProfileProfileParcelResource) Schema(ctx context.Conte
 				},
 			},
 			"authentication_type_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `requires_authentication` being equal to `true`").String,
 				Optional:            true,
 			},
 			"profile_username": schema.StringAttribute{
@@ -128,7 +128,7 @@ func (r *TransportCellularProfileProfileParcelResource) Schema(ctx context.Conte
 				Optional:            true,
 			},
 			"profile_username_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `requires_authentication` being equal to `true`").String,
 				Optional:            true,
 			},
 			"profile_password": schema.StringAttribute{
@@ -136,7 +136,7 @@ func (r *TransportCellularProfileProfileParcelResource) Schema(ctx context.Conte
 				Optional:            true,
 			},
 			"profile_password_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `requires_authentication` being equal to `true`").String,
 				Optional:            true,
 			},
 			"packet_data_network_type": schema.StringAttribute{

--- a/internal/provider/resource_sdwan_transport_cellular_profile_feature_test.go
+++ b/internal/provider/resource_sdwan_transport_cellular_profile_feature_test.go
@@ -76,6 +76,7 @@ func testAccSdwanTransportCellularProfileProfileParcelConfig_all() string {
 	config += `	feature_profile_id = sdwan_transport_feature_profile.test.id` + "\n"
 	config += `	profile_id = 1` + "\n"
 	config += `	access_point_name = "apn1"` + "\n"
+	config += `	requires_authentication = true` + "\n"
 	config += `	authentication_type = "pap"` + "\n"
 	config += `	profile_username = "example"` + "\n"
 	config += `	profile_password = "example123!"` + "\n"

--- a/internal/provider/resource_sdwan_transport_management_vpn_feature.go
+++ b/internal/provider/resource_sdwan_transport_management_vpn_feature.go
@@ -227,7 +227,7 @@ func (r *TransportManagementVPNProfileParcelResource) Schema(ctx context.Context
 							},
 						},
 						"administrative_distance_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `gateway` being equal to `null0`").String,
 							Optional:            true,
 						},
 					},
@@ -295,7 +295,7 @@ func (r *TransportManagementVPNProfileParcelResource) Schema(ctx context.Context
 							},
 						},
 						"nat_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `gateway` being equal to `nat`").String,
 							Optional:            true,
 						},
 					},

--- a/internal/provider/resource_sdwan_transport_management_vpn_interface_ethernet_feature.go
+++ b/internal/provider/resource_sdwan_transport_management_vpn_interface_ethernet_feature.go
@@ -140,7 +140,7 @@ func (r *TransportManagementVPNInterfaceEthernetProfileParcelResource) Schema(ct
 				},
 			},
 			"ipv4_dhcp_distance_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `dynamic`").String,
 				Optional:            true,
 			},
 			"ipv4_address": schema.StringAttribute{
@@ -148,7 +148,7 @@ func (r *TransportManagementVPNInterfaceEthernetProfileParcelResource) Schema(ct
 				Optional:            true,
 			},
 			"ipv4_address_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`").String,
 				Optional:            true,
 			},
 			"ipv4_subnet_mask": schema.StringAttribute{
@@ -159,7 +159,7 @@ func (r *TransportManagementVPNInterfaceEthernetProfileParcelResource) Schema(ct
 				},
 			},
 			"ipv4_subnet_mask_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`").String,
 				Optional:            true,
 			},
 			"ipv4_secondary_addresses": schema.ListNestedAttribute{
@@ -233,7 +233,7 @@ func (r *TransportManagementVPNInterfaceEthernetProfileParcelResource) Schema(ct
 				},
 			},
 			"ipv6_address_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv6_configuration_type` being equal to `static`").String,
 				Optional:            true,
 			},
 			"arp_entries": schema.ListNestedAttribute{

--- a/internal/provider/resource_sdwan_transport_t1_e1_controller_feature.go
+++ b/internal/provider/resource_sdwan_transport_t1_e1_controller_feature.go
@@ -185,7 +185,7 @@ func (r *TransportT1E1ControllerProfileParcelResource) Schema(ctx context.Contex
 							},
 						},
 						"length_short_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `cable_length` being equal to `short`").String,
 							Optional:            true,
 						},
 						"length_long": schema.StringAttribute{
@@ -196,7 +196,7 @@ func (r *TransportT1E1ControllerProfileParcelResource) Schema(ctx context.Contex
 							},
 						},
 						"length_long_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `cable_length` being equal to `long`").String,
 							Optional:            true,
 						},
 						"clock_source": schema.StringAttribute{

--- a/internal/provider/resource_sdwan_transport_wan_vpn_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_feature.go
@@ -228,7 +228,7 @@ func (r *TransportWANVPNProfileParcelResource) Schema(ctx context.Context, req r
 							},
 						},
 						"administrative_distance_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `gateway` being equal to `null0`").String,
 							Optional:            true,
 						},
 					},
@@ -296,7 +296,7 @@ func (r *TransportWANVPNProfileParcelResource) Schema(ctx context.Context, req r
 							},
 						},
 						"nat_variable": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `gateway` being equal to `nat`").String,
 							Optional:            true,
 						},
 					},

--- a/internal/provider/resource_sdwan_transport_wan_vpn_interface_ethernet_feature.go
+++ b/internal/provider/resource_sdwan_transport_wan_vpn_interface_ethernet_feature.go
@@ -140,7 +140,7 @@ func (r *TransportWANVPNInterfaceEthernetProfileParcelResource) Schema(ctx conte
 				},
 			},
 			"ipv4_dhcp_distance_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `dynamic`").String,
 				Optional:            true,
 			},
 			"ipv4_address": schema.StringAttribute{
@@ -148,7 +148,7 @@ func (r *TransportWANVPNInterfaceEthernetProfileParcelResource) Schema(ctx conte
 				Optional:            true,
 			},
 			"ipv4_address_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`").String,
 				Optional:            true,
 			},
 			"ipv4_subnet_mask": schema.StringAttribute{
@@ -159,7 +159,7 @@ func (r *TransportWANVPNInterfaceEthernetProfileParcelResource) Schema(ctx conte
 				},
 			},
 			"ipv4_subnet_mask_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv4_configuration_type` being equal to `static`").String,
 				Optional:            true,
 			},
 			"ipv4_secondary_addresses": schema.ListNestedAttribute{
@@ -236,7 +236,7 @@ func (r *TransportWANVPNInterfaceEthernetProfileParcelResource) Schema(ctx conte
 				},
 			},
 			"ipv6_address_variable": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `ipv6_configuration_type` being equal to `static`").String,
 				Optional:            true,
 			},
 			"ipv6_secondary_addresses": schema.ListNestedAttribute{

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.6.1 (unreleased)
+
+- BREAKING CHANGE: Replaces `no_authentication` attribute of `sdwan_transport_cellular_profile_feature` with `requires_authentication`
+
 ## 0.6.0
 
 - Delete configuration group when an error is encountered during creation, [link](https://github.com/CiscoDevNet/terraform-provider-sdwan/issues/390)


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Resolves issue #420 by replaceing `no_authentication` attribute of `sdwan_transport_cellular_profile_feature` with `requires_authentication`. Due to the expected payload structure we cannot simple add a default value to `authentication_type` without converting the resource to be manual generated.

Instead, when `requires_authentication` is `false` the `noAuthentication` parameter will be set to `none` and when `requires_authentication` set to `true` the `authentication_type`, `profile_username`, and `profile_password` will be expected.

### Types of Changes
<!-- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Build/CI change
* [ ] Code quality improvement/refactoring/documentation (no functional changes)

### Checklist
<!-- Go over all of the following points, and put an x in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] My code follows the code style of this project
* [x] I have added tests to cover my changes
* [x] All new and existing tests pass locally