### PR TITLE
[UX2.0] Resolve Issue #412

### DIFF
--- a/gen/definitions/profile_parcels/service_route_policy.yaml
+++ b/gen/definitions/profile_parcels/service_route_policy.yaml
@@ -14,6 +14,7 @@ attributes:
     example: f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac
     test_value: sdwan_transport_feature_profile.test.id
   - model_name: defaultAction
+    dynamic_default: true
     example: accept
   - model_name: sequences
     tf_name:

--- a/gen/definitions/profile_parcels/system_ipv4_device_access.yaml
+++ b/gen/definitions/profile_parcels/system_ipv4_device_access.yaml
@@ -14,6 +14,7 @@ attributes:
     example: f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac
     test_value: sdwan_system_feature_profile.test.id
   - model_name: defaultAction
+    dynamic_default: true
     example: drop
   - model_name: sequences
     attributes:

--- a/gen/definitions/profile_parcels/system_ipv6_device_access.yaml
+++ b/gen/definitions/profile_parcels/system_ipv6_device_access.yaml
@@ -14,6 +14,7 @@ attributes:
     example: f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac
     test_value: sdwan_system_feature_profile.test.id
   - model_name: defaultAction
+    dynamic_default: true
     example: drop
   - model_name: sequences
     attributes:

--- a/gen/definitions/profile_parcels/transport_ipv4_acl.yaml
+++ b/gen/definitions/profile_parcels/transport_ipv4_acl.yaml
@@ -14,6 +14,7 @@ attributes:
     example: f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac
     test_value: sdwan_transport_feature_profile.test.id
   - model_name: defaultAction
+    dynamic_default: true
     example: drop
   - model_name: sequences
     attributes: 

--- a/gen/definitions/profile_parcels/transport_ipv6_acl.yaml
+++ b/gen/definitions/profile_parcels/transport_ipv6_acl.yaml
@@ -14,6 +14,7 @@ attributes:
     example: f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac
     test_value: sdwan_transport_feature_profile.test.id
   - model_name: defaultAction
+    dynamic_default: true
     example: drop
   - model_name: sequences
     attributes: 

--- a/gen/definitions/profile_parcels/transport_route_policy.yaml
+++ b/gen/definitions/profile_parcels/transport_route_policy.yaml
@@ -14,6 +14,7 @@ attributes:
     example: f6dd22c8-0b4f-496c-9a0b-6813d1f8b8ac
     test_value: sdwan_transport_feature_profile.test.id
   - model_name: defaultAction
+    dynamic_default: true
     example: accept
   - model_name: sequences
     tf_name:

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -271,6 +271,7 @@ type YamlConfigAttribute struct {
 	TestTags                []string                       `yaml:"test_tags"`
 	RequiresConstAndVar     bool                           `yaml:"requires_const_and_var"`
 	RequiresReplace         bool                           `yaml:"requires_replace"`
+	DynamicDefault          bool                           `yaml:"dynamic_default"`
 }
 
 type YamlConfigConditionalAttribute struct {

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -84,7 +84,7 @@ attribute:
   test_tags: list(str(), required=False) # List of test tags, attribute is only included in acceptance tests if an environment variable with one of these tags is configured
   requires_const_and_var: bool(required=False) # If true will include both constant and variable values in payload
   requires_replace: bool(required=False) # If true resource will be recreated when attribute is changed
-  dynamic_default: bool(required=False)
+  dynamic_default: bool(required=False) # If true when the provided value matches the default value `optionType` will be set to `default` rather than `global`
 
 conditional_attribute:
   name: str() # Reference to other attribute

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -84,6 +84,7 @@ attribute:
   test_tags: list(str(), required=False) # List of test tags, attribute is only included in acceptance tests if an environment variable with one of these tags is configured
   requires_const_and_var: bool(required=False) # If true will include both constant and variable values in payload
   requires_replace: bool(required=False) # If true resource will be recreated when attribute is changed
+  dynamic_default: bool(required=False)
 
 conditional_attribute:
   name: str() # Reference to other attribute

--- a/gen/templates/profile_parcels/model.go
+++ b/gen/templates/profile_parcels/model.go
@@ -185,7 +185,7 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context) string {
 		body, _ = sjson.Set(body, path+"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "variable")
 		body, _ = sjson.Set(body, path+"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", data.{{toGoName .TfName}}Variable.ValueString())
 		}
-	} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if data.{{toGoName .TfName}}.IsNull() {
+	} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if data.{{toGoName .TfName}}.IsNull() {{if and .DynamicDefault .DefaultValuePresent}}|| data.{{toGoName .TfName}}.ValueString() == "{{.DefaultValue}}"{{end}} {
 		if true{{if ne .ConditionalAttribute.Name ""}} {{if eq .ConditionalAttribute.Type "Bool"}} && data.{{toGoName .ConditionalAttribute.Name}}.ValueBool() == {{.ConditionalAttribute.Value}} {{else}} && data.{{toGoName .ConditionalAttribute.Name}}.ValueString() == "{{.ConditionalAttribute.Value}}" {{end}}{{end}} {
 		body, _ = sjson.Set(body, path+"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "default")
 		{{if or .DefaultValue .DefaultValueEmptyString}}body, _ = sjson.Set(body, path+"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}}){{end}}
@@ -389,7 +389,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 		va := res.Get(path + "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 		{{if .Variable}}if t.String() == "variable" {
 			data.{{toGoName .TfName}}Variable = types.StringValue(va.String())
-		} else{{end}} if t.String() == "global" {
+		} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 			{{- if eq .Type "StringInt64" }}
 			data.{{toGoName .TfName}} = types.StringValue(va.String())
 			{{- else}}
@@ -517,7 +517,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 		va := res.Get(path + "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 		{{if .Variable}}if t.String() == "variable" {
 			data.{{toGoName .TfName}}Variable = types.StringValue(va.String())
-		} else{{end}} if t.String() == "global" {
+		} else{{end}} if t.String() == "global"{{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 			{{- if eq .Type "StringInt64" }}
 			data.{{toGoName .TfName}} = types.StringValue(va.String())
 			{{- else}}

--- a/gen/templates/profile_parcels/model.go
+++ b/gen/templates/profile_parcels/model.go
@@ -230,7 +230,7 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context) string {
 				itemBody, _ = sjson.Set(itemBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "variable")
 				itemBody, _ = sjson.Set(itemBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", item.{{toGoName .TfName}}Variable.ValueString())
 				}
-			} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if item.{{toGoName .TfName}}.IsNull() {
+			} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if item.{{toGoName .TfName}}.IsNull() {{if and .DynamicDefault .DefaultValuePresent}}|| data.{{toGoName .TfName}}.ValueString() == "{{.DefaultValue}}"{{end}} {
 				if true{{if ne .ConditionalAttribute.Name ""}} {{if eq .ConditionalAttribute.Type "Bool"}} && item.{{toGoName .ConditionalAttribute.Name}}.ValueBool() == {{.ConditionalAttribute.Value}} {{else}} && item.{{toGoName .ConditionalAttribute.Name}}.ValueString() == "{{.ConditionalAttribute.Value}}" {{end}}{{end}} {
 				itemBody, _ = sjson.Set(itemBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "default")
 				{{if or .DefaultValue .DefaultValueEmptyString}}itemBody, _ = sjson.Set(itemBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}}){{end}}
@@ -275,7 +275,7 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context) string {
 						itemChildBody, _ = sjson.Set(itemChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "variable")
 						itemChildBody, _ = sjson.Set(itemChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", childItem.{{toGoName .TfName}}Variable.ValueString())
 						}
-					} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if childItem.{{toGoName .TfName}}.IsNull() {
+					} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if childItem.{{toGoName .TfName}}.IsNull() {{if and .DynamicDefault .DefaultValuePresent}}|| data.{{toGoName .TfName}}.ValueString() == "{{.DefaultValue}}"{{end}} {
 						if true{{if ne .ConditionalAttribute.Name ""}} {{if eq .ConditionalAttribute.Type "Bool"}} && childItem.{{toGoName .ConditionalAttribute.Name}}.ValueBool() == {{.ConditionalAttribute.Value}} {{else}} && childItem.{{toGoName .ConditionalAttribute.Name}}.ValueString() == "{{.ConditionalAttribute.Value}}" {{end}}{{end}} {
 						itemChildBody, _ = sjson.Set(itemChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "default")
 						{{if or .DefaultValue .DefaultValueEmptyString}}itemChildBody, _ = sjson.Set(itemChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}}){{end}}
@@ -320,7 +320,7 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context) string {
 								itemChildChildBody, _ = sjson.Set(itemChildChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "variable")
 								itemChildChildBody, _ = sjson.Set(itemChildChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", childChildItem.{{toGoName .TfName}}Variable.ValueString())
 								}
-							} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if childChildItem.{{toGoName .TfName}}.IsNull() {
+							} else {{end}}{{if and .DefaultValuePresent (not .ExcludeNull)}}if childChildItem.{{toGoName .TfName}}.IsNull() {{if and .DynamicDefault .DefaultValuePresent}}|| data.{{toGoName .TfName}}.ValueString() == "{{.DefaultValue}}"{{end}} {
 								if true{{if ne .ConditionalAttribute.Name ""}} {{if eq .ConditionalAttribute.Type "Bool"}} && childChildItem.{{toGoName .ConditionalAttribute.Name}}.ValueBool() == {{.ConditionalAttribute.Value}} {{else}} && childChildItem.{{toGoName .ConditionalAttribute.Name}}.ValueString() == "{{.ConditionalAttribute.Value}}" {{end}}{{end}} {
 								itemChildChildBody, _ = sjson.Set(itemChildChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.optionType", "default")
 								{{if or .DefaultValue .DefaultValueEmptyString}}itemChildChildBody, _ = sjson.Set(itemChildChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value", {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}}){{end}}

--- a/gen/templates/profile_parcels/model.go
+++ b/gen/templates/profile_parcels/model.go
@@ -415,7 +415,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 				va := v.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 				{{if .Variable}}if t.String() == "variable" {
 					item.{{toGoName .TfName}}Variable = types.StringValue(va.String())
-				} else{{end}} if t.String() == "global" {
+				} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 					{{- if eq .Type "StringInt64" }}
 					item.{{toGoName .TfName}} = types.StringValue(va.String())
 					{{- else}}
@@ -440,7 +440,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 						va := cv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 						{{if .Variable}}if t.String() == "variable" {
 							cItem.{{toGoName .TfName}}Variable = types.StringValue(va.String())
-						} else{{end}} if t.String() == "global" {
+						} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 							{{- if eq .Type "StringInt64" }}
 							cItem.{{toGoName .TfName}} = types.StringValue(va.String())
 							{{- else}}
@@ -465,7 +465,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 								va := ccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 								{{if .Variable}}if t.String() == "variable" {
 									ccItem.{{toGoName .TfName}}Variable = types.StringValue(va.String())
-								} else{{end}} if t.String() == "global" {
+								} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 									{{- if eq .Type "StringInt64" }}
 									ccItem.{{toGoName .TfName}} = types.StringValue(va.String())
 									{{- else}}
@@ -517,7 +517,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 		va := res.Get(path + "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 		{{if .Variable}}if t.String() == "variable" {
 			data.{{toGoName .TfName}}Variable = types.StringValue(va.String())
-		} else{{end}} if t.String() == "global"{{if .DynamicDefault}}|| t.String() == "default"{{end}} {
+		} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 			{{- if eq .Type "StringInt64" }}
 			data.{{toGoName .TfName}} = types.StringValue(va.String())
 			{{- else}}
@@ -608,7 +608,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 			va := r.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 			{{if .Variable}}if t.String() == "variable" {
 				data.{{$list}}[i].{{toGoName .TfName}}Variable = types.StringValue(va.String())
-			} else{{end}} if t.String() == "global" {
+			} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 				{{- if eq .Type "StringInt64" }}
 				data.{{$list}}[i].{{toGoName .TfName}} = types.StringValue(va.String())
 				{{- else}}
@@ -699,7 +699,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 				va := cr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 				{{if .Variable}}if t.String() == "variable" {
 					data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}}Variable = types.StringValue(va.String())
-				} else{{end}} if t.String() == "global" {
+				} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 					{{- if eq .Type "StringInt64" }}
 					data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = types.StringValue(va.String())
 					{{- else}}
@@ -790,7 +790,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 					va := ccr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}.value")
 					{{if .Variable}}if t.String() == "variable" {
 						data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}}Variable = types.StringValue(va.String())
-					} else{{end}} if t.String() == "global" {
+					} else{{end}} if t.String() == "global" {{if .DynamicDefault}}|| t.String() == "default"{{end}} {
 						{{- if eq .Type "StringInt64" }}
 						data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}} = types.StringValue(va.String())
 						{{- else}}

--- a/internal/provider/model_sdwan_service_route_policy_feature.go
+++ b/internal/provider/model_sdwan_service_route_policy_feature.go
@@ -109,7 +109,7 @@ func (data ServiceRoutePolicy) toBody(ctx context.Context) string {
 	body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	path := "data."
-	if data.DefaultAction.IsNull() {
+	if data.DefaultAction.IsNull() || data.DefaultAction.ValueString() == "reject" {
 		if true {
 			body, _ = sjson.Set(body, path+"defaultAction.optionType", "default")
 			body, _ = sjson.Set(body, path+"defaultAction.value", "reject")
@@ -369,7 +369,7 @@ func (data *ServiceRoutePolicy) fromBody(ctx context.Context, res gjson.Result) 
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}
@@ -656,7 +656,7 @@ func (data *ServiceRoutePolicy) updateFromBody(ctx context.Context, res gjson.Re
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}

--- a/internal/provider/model_sdwan_system_ipv4_device_access_feature.go
+++ b/internal/provider/model_sdwan_system_ipv4_device_access_feature.go
@@ -79,7 +79,7 @@ func (data SystemIPv4DeviceAccess) toBody(ctx context.Context) string {
 	body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	path := "data."
-	if data.DefaultAction.IsNull() {
+	if data.DefaultAction.IsNull() || data.DefaultAction.ValueString() == "drop" {
 		if true {
 			body, _ = sjson.Set(body, path+"defaultAction.optionType", "default")
 			body, _ = sjson.Set(body, path+"defaultAction.value", "drop")
@@ -187,7 +187,7 @@ func (data *SystemIPv4DeviceAccess) fromBody(ctx context.Context, res gjson.Resu
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}
@@ -292,7 +292,7 @@ func (data *SystemIPv4DeviceAccess) updateFromBody(ctx context.Context, res gjso
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}

--- a/internal/provider/model_sdwan_system_ipv6_device_access_feature.go
+++ b/internal/provider/model_sdwan_system_ipv6_device_access_feature.go
@@ -79,7 +79,7 @@ func (data SystemIPv6DeviceAccess) toBody(ctx context.Context) string {
 	body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	path := "data."
-	if data.DefaultAction.IsNull() {
+	if data.DefaultAction.IsNull() || data.DefaultAction.ValueString() == "drop" {
 		if true {
 			body, _ = sjson.Set(body, path+"defaultAction.optionType", "default")
 			body, _ = sjson.Set(body, path+"defaultAction.value", "drop")
@@ -192,7 +192,7 @@ func (data *SystemIPv6DeviceAccess) fromBody(ctx context.Context, res gjson.Resu
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}
@@ -297,7 +297,7 @@ func (data *SystemIPv6DeviceAccess) updateFromBody(ctx context.Context, res gjso
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}

--- a/internal/provider/model_sdwan_transport_ipv4_acl_feature.go
+++ b/internal/provider/model_sdwan_transport_ipv4_acl_feature.go
@@ -106,7 +106,7 @@ func (data TransportIPv4ACL) toBody(ctx context.Context) string {
 	body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	path := "data."
-	if data.DefaultAction.IsNull() {
+	if data.DefaultAction.IsNull() || data.DefaultAction.ValueString() == "drop" {
 		if true {
 			body, _ = sjson.Set(body, path+"defaultAction.optionType", "default")
 			body, _ = sjson.Set(body, path+"defaultAction.value", "drop")
@@ -332,7 +332,7 @@ func (data *TransportIPv4ACL) fromBody(ctx context.Context, res gjson.Result) {
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}
@@ -573,7 +573,7 @@ func (data *TransportIPv4ACL) updateFromBody(ctx context.Context, res gjson.Resu
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}

--- a/internal/provider/model_sdwan_transport_ipv6_acl_feature.go
+++ b/internal/provider/model_sdwan_transport_ipv6_acl_feature.go
@@ -104,7 +104,7 @@ func (data TransportIPv6ACL) toBody(ctx context.Context) string {
 	body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	path := "data."
-	if data.DefaultAction.IsNull() {
+	if data.DefaultAction.IsNull() || data.DefaultAction.ValueString() == "drop" {
 		if true {
 			body, _ = sjson.Set(body, path+"defaultAction.optionType", "default")
 			body, _ = sjson.Set(body, path+"defaultAction.value", "drop")
@@ -316,7 +316,7 @@ func (data *TransportIPv6ACL) fromBody(ctx context.Context, res gjson.Result) {
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}
@@ -553,7 +553,7 @@ func (data *TransportIPv6ACL) updateFromBody(ctx context.Context, res gjson.Resu
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}

--- a/internal/provider/model_sdwan_transport_route_policy_feature.go
+++ b/internal/provider/model_sdwan_transport_route_policy_feature.go
@@ -109,7 +109,7 @@ func (data TransportRoutePolicy) toBody(ctx context.Context) string {
 	body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	path := "data."
-	if data.DefaultAction.IsNull() {
+	if data.DefaultAction.IsNull() || data.DefaultAction.ValueString() == "reject" {
 		if true {
 			body, _ = sjson.Set(body, path+"defaultAction.optionType", "default")
 			body, _ = sjson.Set(body, path+"defaultAction.value", "reject")
@@ -369,7 +369,7 @@ func (data *TransportRoutePolicy) fromBody(ctx context.Context, res gjson.Result
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}
@@ -656,7 +656,7 @@ func (data *TransportRoutePolicy) updateFromBody(ctx context.Context, res gjson.
 
 	if t := res.Get(path + "defaultAction.optionType"); t.Exists() {
 		va := res.Get(path + "defaultAction.value")
-		if t.String() == "global" {
+		if t.String() == "global" || t.String() == "default" {
 			data.DefaultAction = types.StringValue(va.String())
 		}
 	}


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Add the `dynamic_default` parameter to the generator to resolve issue #412. specifically when configured properties value matches the default value the `optionType` should be set to `default` rather than `global`.

Also resolves comment on #421.

### Types of Changes
<!-- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Build/CI change
* [ ] Code quality improvement/refactoring/documentation (no functional changes)

### Checklist
<!-- Go over all of the following points, and put an x in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] My code follows the code style of this project
* [x] I have added tests to cover my changes
* [x] All new and existing tests pass locally