### PR TITLE
[UX2.0] Resolve Issue #413

### DIFF
--- a/docs/data-sources/transport_routing_bgp_feature.md
+++ b/docs/data-sources/transport_routing_bgp_feature.md
@@ -144,16 +144,24 @@ Read-Only:
 
 Read-Only:
 
+- `disable_peer_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer
+- `disable_peer_max_number_of_prefixes_variable` (String) Variable name
+- `disable_peer_message_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message
+- `disable_peer_message_threshold_variable` (String) Variable name
 - `family_type` (String) Set IPv4 unicast address family
 - `in_route_policy_id` (String)
-- `max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer
-- `max_number_of_prefixes_variable` (String) Variable name
 - `out_route_policy_id` (String)
 - `policy_type` (String) Neighbor received maximum prefix policy is disabled.
 - `restart_interval` (Number) Set the restart interval(minutes) when to restart BGP connection if threshold is exceeded
 - `restart_interval_variable` (String) Variable name
-- `threshold` (Number) Set threshold(1 to 100) at which to generate a warning message
-- `threshold_variable` (String) Variable name
+- `restart_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer
+- `restart_max_number_of_prefixes_variable` (String) Variable name
+- `restart_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message
+- `restart_threshold_variable` (String) Variable name
+- `warning_message_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer
+- `warning_message_max_number_of_prefixes_variable` (String) Variable name
+- `warning_message_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message
+- `warning_message_threshold_variable` (String) Variable name
 
 
 

--- a/docs/data-sources/transport_routing_bgp_feature.md
+++ b/docs/data-sources/transport_routing_bgp_feature.md
@@ -146,8 +146,8 @@ Read-Only:
 
 - `disable_peer_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer
 - `disable_peer_max_number_of_prefixes_variable` (String) Variable name
-- `disable_peer_message_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message
-- `disable_peer_message_threshold_variable` (String) Variable name
+- `disable_peer_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message
+- `disable_peer_threshold_variable` (String) Variable name
 - `family_type` (String) Set IPv4 unicast address family
 - `in_route_policy_id` (String)
 - `out_route_policy_id` (String)

--- a/docs/resources/transport_routing_bgp_feature.md
+++ b/docs/resources/transport_routing_bgp_feature.md
@@ -54,11 +54,11 @@ resource "sdwan_transport_routing_bgp_feature" "example" {
       allowas_in_number       = 1
       address_families = [
         {
-          family_type            = "ipv4-unicast"
-          max_number_of_prefixes = 2000
-          threshold              = 75
-          policy_type            = "restart"
-          restart_interval       = 30
+          family_type                    = "ipv4-unicast"
+          policy_type                    = "restart"
+          restart_max_number_of_prefixes = 2000
+          restart_threshold              = 75
+          restart_interval               = 30
         }
       ]
     }
@@ -298,21 +298,36 @@ Optional:
 
 Optional:
 
+- `disable_peer_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer, Attribute conditional on `policy_type` being equal to `disable-peer`
+  - Range: `1`-`4294967295`
+- `disable_peer_max_number_of_prefixes_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`
+- `disable_peer_message_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `disable-peer`
+  - Range: `1`-`100`
+  - Default value: `75`
+- `disable_peer_message_threshold_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`
 - `family_type` (String) Set IPv4 unicast address family
   - Choices: `ipv4-unicast`, `vpnv4-unicast`, `vpnv6-unicast`
 - `in_route_policy_id` (String)
-- `max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer
-  - Range: `1`-`4294967295`
-- `max_number_of_prefixes_variable` (String) Variable name
 - `out_route_policy_id` (String)
 - `policy_type` (String) Neighbor received maximum prefix policy is disabled.
-- `restart_interval` (Number) Set the restart interval(minutes) when to restart BGP connection if threshold is exceeded
+  - Choices: `restart`, `off`, `warning-only`, `disable-peer`
+- `restart_interval` (Number) Set the restart interval(minutes) when to restart BGP connection if threshold is exceeded, Attribute conditional on `policy_type` being equal to `restart`
   - Range: `1`-`65535`
-- `restart_interval_variable` (String) Variable name
-- `threshold` (Number) Set threshold(1 to 100) at which to generate a warning message
+- `restart_interval_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `restart`
+- `restart_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer, Attribute conditional on `policy_type` being equal to `restart`
+  - Range: `1`-`4294967295`
+- `restart_max_number_of_prefixes_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `restart`
+- `restart_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `restart`
   - Range: `1`-`100`
   - Default value: `75`
-- `threshold_variable` (String) Variable name
+- `restart_threshold_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `restart`
+- `warning_message_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer, Attribute conditional on `policy_type` being equal to `warning-only`
+  - Range: `1`-`4294967295`
+- `warning_message_max_number_of_prefixes_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `warning-only`
+- `warning_message_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `warning-only`
+  - Range: `1`-`100`
+  - Default value: `75`
+- `warning_message_threshold_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `warning-only`
 
 
 

--- a/docs/resources/transport_routing_bgp_feature.md
+++ b/docs/resources/transport_routing_bgp_feature.md
@@ -301,10 +301,10 @@ Optional:
 - `disable_peer_max_number_of_prefixes` (Number) Set maximum number of prefixes accepted from BGP peer, Attribute conditional on `policy_type` being equal to `disable-peer`
   - Range: `1`-`4294967295`
 - `disable_peer_max_number_of_prefixes_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`
-- `disable_peer_message_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `disable-peer`
+- `disable_peer_threshold` (Number) Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `disable-peer`
   - Range: `1`-`100`
   - Default value: `75`
-- `disable_peer_message_threshold_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`
+- `disable_peer_threshold_variable` (String) Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`
 - `family_type` (String) Set IPv4 unicast address family
   - Choices: `ipv4-unicast`, `vpnv4-unicast`, `vpnv6-unicast`
 - `in_route_policy_id` (String)

--- a/examples/resources/sdwan_transport_routing_bgp_feature/resource.tf
+++ b/examples/resources/sdwan_transport_routing_bgp_feature/resource.tf
@@ -37,11 +37,11 @@ resource "sdwan_transport_routing_bgp_feature" "example" {
       allowas_in_number       = 1
       address_families = [
         {
-          family_type            = "ipv4-unicast"
-          max_number_of_prefixes = 2000
-          threshold              = 75
-          policy_type            = "restart"
-          restart_interval       = 30
+          family_type                    = "ipv4-unicast"
+          policy_type                    = "restart"
+          restart_max_number_of_prefixes = 2000
+          restart_threshold              = 75
+          restart_interval               = 30
         }
       ]
     }

--- a/gen/definitions/profile_parcels/transport_routing_bgp.yaml
+++ b/gen/definitions/profile_parcels/transport_routing_bgp.yaml
@@ -103,22 +103,69 @@ attributes:
       - model_name: familyType
         id: true
         example: ipv4-unicast
+      - model_name: policyType
+        data_path: [maxPrefixConfig]
+        type: String
+        enum_values: [restart, off, warning-only, disable-peer]
+        example: restart
       - model_name: prefixNum
-        tf_name: max_number_of_prefixes
+        tf_name: restart_max_number_of_prefixes
         data_path: [maxPrefixConfig]
         example: 2000
+        conditional_attribute:
+          name: policyType
+          value: restart
       - model_name: threshold
+        tf_name: restart_threshold
         data_path: [maxPrefixConfig]
         default_value: 75
         default_value_present: true
         example: 75
-      - model_name: policyType
-        data_path: [maxPrefixConfig]
-        type: String
-        example: restart
+        conditional_attribute:
+          name: policyType
+          value: restart
       - model_name: restartInterval
         data_path: [maxPrefixConfig]
         example: 30
+        conditional_attribute:
+          name: policyType
+          value: restart
+      - model_name: prefixNum
+        tf_name: warning_message_max_number_of_prefixes
+        data_path: [maxPrefixConfig]
+        example: 2000
+        exclude_test: true
+        conditional_attribute:
+          name: policyType
+          value: warning-only
+      - model_name: threshold
+        tf_name: warning_message_threshold
+        data_path: [maxPrefixConfig]
+        default_value: 75
+        default_value_present: true
+        example: 75
+        exclude_test: true
+        conditional_attribute:
+          name: policyType
+          value: warning-only
+      - model_name: prefixNum
+        tf_name: disable_peer_max_number_of_prefixes
+        data_path: [maxPrefixConfig]
+        example: 2000
+        exclude_test: true
+        conditional_attribute:
+          name: policyType
+          value: disable-peer
+      - model_name: threshold
+        tf_name: disable_peer_message_threshold
+        data_path: [maxPrefixConfig]
+        default_value: 75
+        default_value_present: true
+        example: 75
+        exclude_test: true
+        conditional_attribute:
+          name: policyType
+          value: disable-peer
       - model_name: refId
         tf_name: in_route_policy_id
         data_path: [inRoutePolicy]

--- a/gen/definitions/profile_parcels/transport_routing_bgp.yaml
+++ b/gen/definitions/profile_parcels/transport_routing_bgp.yaml
@@ -157,7 +157,7 @@ attributes:
           name: policyType
           value: disable-peer
       - model_name: threshold
-        tf_name: disable_peer_message_threshold
+        tf_name: disable_peer_threshold
         data_path: [maxPrefixConfig]
         default_value: 75
         default_value_present: true

--- a/internal/provider/data_source_sdwan_transport_routing_bgp_feature.go
+++ b/internal/provider/data_source_sdwan_transport_routing_bgp_feature.go
@@ -388,11 +388,11 @@ func (d *TransportRoutingBGPProfileParcelDataSource) Schema(ctx context.Context,
 										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 										Computed:            true,
 									},
-									"disable_peer_message_threshold": schema.Int64Attribute{
+									"disable_peer_threshold": schema.Int64Attribute{
 										MarkdownDescription: "Set threshold(1 to 100) at which to generate a warning message",
 										Computed:            true,
 									},
-									"disable_peer_message_threshold_variable": schema.StringAttribute{
+									"disable_peer_threshold_variable": schema.StringAttribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 										Computed:            true,
 									},

--- a/internal/provider/data_source_sdwan_transport_routing_bgp_feature.go
+++ b/internal/provider/data_source_sdwan_transport_routing_bgp_feature.go
@@ -336,24 +336,24 @@ func (d *TransportRoutingBGPProfileParcelDataSource) Schema(ctx context.Context,
 										MarkdownDescription: "Set IPv4 unicast address family",
 										Computed:            true,
 									},
-									"max_number_of_prefixes": schema.Int64Attribute{
+									"policy_type": schema.StringAttribute{
+										MarkdownDescription: "Neighbor received maximum prefix policy is disabled.",
+										Computed:            true,
+									},
+									"restart_max_number_of_prefixes": schema.Int64Attribute{
 										MarkdownDescription: "Set maximum number of prefixes accepted from BGP peer",
 										Computed:            true,
 									},
-									"max_number_of_prefixes_variable": schema.StringAttribute{
+									"restart_max_number_of_prefixes_variable": schema.StringAttribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 										Computed:            true,
 									},
-									"threshold": schema.Int64Attribute{
+									"restart_threshold": schema.Int64Attribute{
 										MarkdownDescription: "Set threshold(1 to 100) at which to generate a warning message",
 										Computed:            true,
 									},
-									"threshold_variable": schema.StringAttribute{
+									"restart_threshold_variable": schema.StringAttribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
-										Computed:            true,
-									},
-									"policy_type": schema.StringAttribute{
-										MarkdownDescription: "Neighbor received maximum prefix policy is disabled.",
 										Computed:            true,
 									},
 									"restart_interval": schema.Int64Attribute{
@@ -361,6 +361,38 @@ func (d *TransportRoutingBGPProfileParcelDataSource) Schema(ctx context.Context,
 										Computed:            true,
 									},
 									"restart_interval_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+										Computed:            true,
+									},
+									"warning_message_max_number_of_prefixes": schema.Int64Attribute{
+										MarkdownDescription: "Set maximum number of prefixes accepted from BGP peer",
+										Computed:            true,
+									},
+									"warning_message_max_number_of_prefixes_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+										Computed:            true,
+									},
+									"warning_message_threshold": schema.Int64Attribute{
+										MarkdownDescription: "Set threshold(1 to 100) at which to generate a warning message",
+										Computed:            true,
+									},
+									"warning_message_threshold_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+										Computed:            true,
+									},
+									"disable_peer_max_number_of_prefixes": schema.Int64Attribute{
+										MarkdownDescription: "Set maximum number of prefixes accepted from BGP peer",
+										Computed:            true,
+									},
+									"disable_peer_max_number_of_prefixes_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+										Computed:            true,
+									},
+									"disable_peer_message_threshold": schema.Int64Attribute{
+										MarkdownDescription: "Set threshold(1 to 100) at which to generate a warning message",
+										Computed:            true,
+									},
+									"disable_peer_message_threshold_variable": schema.StringAttribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
 										Computed:            true,
 									},

--- a/internal/provider/data_source_sdwan_transport_routing_bgp_feature_test.go
+++ b/internal/provider/data_source_sdwan_transport_routing_bgp_feature_test.go
@@ -64,9 +64,9 @@ func TestAccDataSourceSdwanTransportRoutingBGPProfileParcel(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.as_override", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.allowas_in_number", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.family_type", "ipv4-unicast"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.max_number_of_prefixes", "2000"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.threshold", "75"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.policy_type", "restart"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.restart_max_number_of_prefixes", "2000"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.restart_threshold", "75"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.restart_interval", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv6_neighbors.0.address", "2001::1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.sdwan_transport_routing_bgp_feature.test", "ipv6_neighbors.0.description", "neighbor2"))
@@ -168,9 +168,9 @@ func testAccDataSourceSdwanTransportRoutingBGPProfileParcelConfig() string {
 	config += `	  allowas_in_number = 1` + "\n"
 	config += `	  address_families = [{` + "\n"
 	config += `		family_type = "ipv4-unicast"` + "\n"
-	config += `		max_number_of_prefixes = 2000` + "\n"
-	config += `		threshold = 75` + "\n"
 	config += `		policy_type = "restart"` + "\n"
+	config += `		restart_max_number_of_prefixes = 2000` + "\n"
+	config += `		restart_threshold = 75` + "\n"
 	config += `		restart_interval = 30` + "\n"
 	config += `	}]` + "\n"
 	config += `	}]` + "\n"

--- a/internal/provider/model_sdwan_transport_routing_bgp_feature.go
+++ b/internal/provider/model_sdwan_transport_routing_bgp_feature.go
@@ -211,16 +211,24 @@ type TransportRoutingBGPMplsInterfaces struct {
 }
 
 type TransportRoutingBGPIpv4NeighborsAddressFamilies struct {
-	FamilyType                  types.String `tfsdk:"family_type"`
-	MaxNumberOfPrefixes         types.Int64  `tfsdk:"max_number_of_prefixes"`
-	MaxNumberOfPrefixesVariable types.String `tfsdk:"max_number_of_prefixes_variable"`
-	Threshold                   types.Int64  `tfsdk:"threshold"`
-	ThresholdVariable           types.String `tfsdk:"threshold_variable"`
-	PolicyType                  types.String `tfsdk:"policy_type"`
-	RestartInterval             types.Int64  `tfsdk:"restart_interval"`
-	RestartIntervalVariable     types.String `tfsdk:"restart_interval_variable"`
-	InRoutePolicyId             types.String `tfsdk:"in_route_policy_id"`
-	OutRoutePolicyId            types.String `tfsdk:"out_route_policy_id"`
+	FamilyType                                types.String `tfsdk:"family_type"`
+	PolicyType                                types.String `tfsdk:"policy_type"`
+	RestartMaxNumberOfPrefixes                types.Int64  `tfsdk:"restart_max_number_of_prefixes"`
+	RestartMaxNumberOfPrefixesVariable        types.String `tfsdk:"restart_max_number_of_prefixes_variable"`
+	RestartThreshold                          types.Int64  `tfsdk:"restart_threshold"`
+	RestartThresholdVariable                  types.String `tfsdk:"restart_threshold_variable"`
+	RestartInterval                           types.Int64  `tfsdk:"restart_interval"`
+	RestartIntervalVariable                   types.String `tfsdk:"restart_interval_variable"`
+	WarningMessageMaxNumberOfPrefixes         types.Int64  `tfsdk:"warning_message_max_number_of_prefixes"`
+	WarningMessageMaxNumberOfPrefixesVariable types.String `tfsdk:"warning_message_max_number_of_prefixes_variable"`
+	WarningMessageThreshold                   types.Int64  `tfsdk:"warning_message_threshold"`
+	WarningMessageThresholdVariable           types.String `tfsdk:"warning_message_threshold_variable"`
+	DisablePeerMaxNumberOfPrefixes            types.Int64  `tfsdk:"disable_peer_max_number_of_prefixes"`
+	DisablePeerMaxNumberOfPrefixesVariable    types.String `tfsdk:"disable_peer_max_number_of_prefixes_variable"`
+	DisablePeerMessageThreshold               types.Int64  `tfsdk:"disable_peer_message_threshold"`
+	DisablePeerMessageThresholdVariable       types.String `tfsdk:"disable_peer_message_threshold_variable"`
+	InRoutePolicyId                           types.String `tfsdk:"in_route_policy_id"`
+	OutRoutePolicyId                          types.String `tfsdk:"out_route_policy_id"`
 }
 
 type TransportRoutingBGPIpv6NeighborsAddressFamilies struct {
@@ -778,35 +786,6 @@ func (data TransportRoutingBGP) toBody(ctx context.Context) string {
 							itemChildBody, _ = sjson.Set(itemChildBody, "familyType.value", childItem.FamilyType.ValueString())
 						}
 					}
-
-					if !childItem.MaxNumberOfPrefixesVariable.IsNull() {
-						if true {
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "variable")
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.MaxNumberOfPrefixesVariable.ValueString())
-						}
-					} else if !childItem.MaxNumberOfPrefixes.IsNull() {
-						if true {
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "global")
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.MaxNumberOfPrefixes.ValueInt64())
-						}
-					}
-
-					if !childItem.ThresholdVariable.IsNull() {
-						if true {
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "variable")
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.ThresholdVariable.ValueString())
-						}
-					} else if childItem.Threshold.IsNull() {
-						if true {
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "default")
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", 75)
-						}
-					} else {
-						if true {
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "global")
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.Threshold.ValueInt64())
-						}
-					}
 					if !childItem.PolicyType.IsNull() {
 						if true {
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.policyType.optionType", "global")
@@ -814,15 +793,102 @@ func (data TransportRoutingBGP) toBody(ctx context.Context) string {
 						}
 					}
 
+					if !childItem.RestartMaxNumberOfPrefixesVariable.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "restart" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "variable")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.RestartMaxNumberOfPrefixesVariable.ValueString())
+						}
+					} else if !childItem.RestartMaxNumberOfPrefixes.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "restart" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "global")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.RestartMaxNumberOfPrefixes.ValueInt64())
+						}
+					}
+
+					if !childItem.RestartThresholdVariable.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "restart" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "variable")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.RestartThresholdVariable.ValueString())
+						}
+					} else if childItem.RestartThreshold.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "restart" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "default")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", 75)
+						}
+					} else {
+						if true && childItem.PolicyType.ValueString() == "restart" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "global")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.RestartThreshold.ValueInt64())
+						}
+					}
+
 					if !childItem.RestartIntervalVariable.IsNull() {
-						if true {
+						if true && childItem.PolicyType.ValueString() == "restart" {
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.restartInterval.optionType", "variable")
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.restartInterval.value", childItem.RestartIntervalVariable.ValueString())
 						}
 					} else if !childItem.RestartInterval.IsNull() {
-						if true {
+						if true && childItem.PolicyType.ValueString() == "restart" {
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.restartInterval.optionType", "global")
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.restartInterval.value", childItem.RestartInterval.ValueInt64())
+						}
+					}
+
+					if !childItem.WarningMessageMaxNumberOfPrefixesVariable.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "warning-only" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "variable")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.WarningMessageMaxNumberOfPrefixesVariable.ValueString())
+						}
+					} else if !childItem.WarningMessageMaxNumberOfPrefixes.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "warning-only" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "global")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.WarningMessageMaxNumberOfPrefixes.ValueInt64())
+						}
+					}
+
+					if !childItem.WarningMessageThresholdVariable.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "warning-only" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "variable")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.WarningMessageThresholdVariable.ValueString())
+						}
+					} else if childItem.WarningMessageThreshold.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "warning-only" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "default")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", 75)
+						}
+					} else {
+						if true && childItem.PolicyType.ValueString() == "warning-only" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "global")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.WarningMessageThreshold.ValueInt64())
+						}
+					}
+
+					if !childItem.DisablePeerMaxNumberOfPrefixesVariable.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "disable-peer" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "variable")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.DisablePeerMaxNumberOfPrefixesVariable.ValueString())
+						}
+					} else if !childItem.DisablePeerMaxNumberOfPrefixes.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "disable-peer" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.optionType", "global")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.prefixNum.value", childItem.DisablePeerMaxNumberOfPrefixes.ValueInt64())
+						}
+					}
+
+					if !childItem.DisablePeerMessageThresholdVariable.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "disable-peer" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "variable")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.DisablePeerMessageThresholdVariable.ValueString())
+						}
+					} else if childItem.DisablePeerMessageThreshold.IsNull() {
+						if true && childItem.PolicyType.ValueString() == "disable-peer" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "default")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", 75)
+						}
+					} else {
+						if true && childItem.PolicyType.ValueString() == "disable-peer" {
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "global")
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.DisablePeerMessageThreshold.ValueInt64())
 						}
 					}
 					if !childItem.InRoutePolicyId.IsNull() {
@@ -1850,32 +1916,32 @@ func (data *TransportRoutingBGP) fromBody(ctx context.Context, res gjson.Result)
 							cItem.FamilyType = types.StringValue(va.String())
 						}
 					}
-					cItem.MaxNumberOfPrefixes = types.Int64Null()
-					cItem.MaxNumberOfPrefixesVariable = types.StringNull()
-					if t := cv.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
-						va := cv.Get("maxPrefixConfig.prefixNum.value")
-						if t.String() == "variable" {
-							cItem.MaxNumberOfPrefixesVariable = types.StringValue(va.String())
-						} else if t.String() == "global" {
-							cItem.MaxNumberOfPrefixes = types.Int64Value(va.Int())
-						}
-					}
-					cItem.Threshold = types.Int64Null()
-					cItem.ThresholdVariable = types.StringNull()
-					if t := cv.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
-						va := cv.Get("maxPrefixConfig.threshold.value")
-						if t.String() == "variable" {
-							cItem.ThresholdVariable = types.StringValue(va.String())
-						} else if t.String() == "global" {
-							cItem.Threshold = types.Int64Value(va.Int())
-						}
-					}
 					cItem.PolicyType = types.StringNull()
 
 					if t := cv.Get("maxPrefixConfig.policyType.optionType"); t.Exists() {
 						va := cv.Get("maxPrefixConfig.policyType.value")
 						if t.String() == "global" {
 							cItem.PolicyType = types.StringValue(va.String())
+						}
+					}
+					cItem.RestartMaxNumberOfPrefixes = types.Int64Null()
+					cItem.RestartMaxNumberOfPrefixesVariable = types.StringNull()
+					if t := cv.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
+						va := cv.Get("maxPrefixConfig.prefixNum.value")
+						if t.String() == "variable" {
+							cItem.RestartMaxNumberOfPrefixesVariable = types.StringValue(va.String())
+						} else if t.String() == "global" {
+							cItem.RestartMaxNumberOfPrefixes = types.Int64Value(va.Int())
+						}
+					}
+					cItem.RestartThreshold = types.Int64Null()
+					cItem.RestartThresholdVariable = types.StringNull()
+					if t := cv.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
+						va := cv.Get("maxPrefixConfig.threshold.value")
+						if t.String() == "variable" {
+							cItem.RestartThresholdVariable = types.StringValue(va.String())
+						} else if t.String() == "global" {
+							cItem.RestartThreshold = types.Int64Value(va.Int())
 						}
 					}
 					cItem.RestartInterval = types.Int64Null()
@@ -1886,6 +1952,46 @@ func (data *TransportRoutingBGP) fromBody(ctx context.Context, res gjson.Result)
 							cItem.RestartIntervalVariable = types.StringValue(va.String())
 						} else if t.String() == "global" {
 							cItem.RestartInterval = types.Int64Value(va.Int())
+						}
+					}
+					cItem.WarningMessageMaxNumberOfPrefixes = types.Int64Null()
+					cItem.WarningMessageMaxNumberOfPrefixesVariable = types.StringNull()
+					if t := cv.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
+						va := cv.Get("maxPrefixConfig.prefixNum.value")
+						if t.String() == "variable" {
+							cItem.WarningMessageMaxNumberOfPrefixesVariable = types.StringValue(va.String())
+						} else if t.String() == "global" {
+							cItem.WarningMessageMaxNumberOfPrefixes = types.Int64Value(va.Int())
+						}
+					}
+					cItem.WarningMessageThreshold = types.Int64Null()
+					cItem.WarningMessageThresholdVariable = types.StringNull()
+					if t := cv.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
+						va := cv.Get("maxPrefixConfig.threshold.value")
+						if t.String() == "variable" {
+							cItem.WarningMessageThresholdVariable = types.StringValue(va.String())
+						} else if t.String() == "global" {
+							cItem.WarningMessageThreshold = types.Int64Value(va.Int())
+						}
+					}
+					cItem.DisablePeerMaxNumberOfPrefixes = types.Int64Null()
+					cItem.DisablePeerMaxNumberOfPrefixesVariable = types.StringNull()
+					if t := cv.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
+						va := cv.Get("maxPrefixConfig.prefixNum.value")
+						if t.String() == "variable" {
+							cItem.DisablePeerMaxNumberOfPrefixesVariable = types.StringValue(va.String())
+						} else if t.String() == "global" {
+							cItem.DisablePeerMaxNumberOfPrefixes = types.Int64Value(va.Int())
+						}
+					}
+					cItem.DisablePeerMessageThreshold = types.Int64Null()
+					cItem.DisablePeerMessageThresholdVariable = types.StringNull()
+					if t := cv.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
+						va := cv.Get("maxPrefixConfig.threshold.value")
+						if t.String() == "variable" {
+							cItem.DisablePeerMessageThresholdVariable = types.StringValue(va.String())
+						} else if t.String() == "global" {
+							cItem.DisablePeerMessageThreshold = types.Int64Value(va.Int())
 						}
 					}
 					cItem.InRoutePolicyId = types.StringNull()
@@ -2789,32 +2895,32 @@ func (data *TransportRoutingBGP) updateFromBody(ctx context.Context, res gjson.R
 					data.Ipv4Neighbors[i].AddressFamilies[ci].FamilyType = types.StringValue(va.String())
 				}
 			}
-			data.Ipv4Neighbors[i].AddressFamilies[ci].MaxNumberOfPrefixes = types.Int64Null()
-			data.Ipv4Neighbors[i].AddressFamilies[ci].MaxNumberOfPrefixesVariable = types.StringNull()
-			if t := cr.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
-				va := cr.Get("maxPrefixConfig.prefixNum.value")
-				if t.String() == "variable" {
-					data.Ipv4Neighbors[i].AddressFamilies[ci].MaxNumberOfPrefixesVariable = types.StringValue(va.String())
-				} else if t.String() == "global" {
-					data.Ipv4Neighbors[i].AddressFamilies[ci].MaxNumberOfPrefixes = types.Int64Value(va.Int())
-				}
-			}
-			data.Ipv4Neighbors[i].AddressFamilies[ci].Threshold = types.Int64Null()
-			data.Ipv4Neighbors[i].AddressFamilies[ci].ThresholdVariable = types.StringNull()
-			if t := cr.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
-				va := cr.Get("maxPrefixConfig.threshold.value")
-				if t.String() == "variable" {
-					data.Ipv4Neighbors[i].AddressFamilies[ci].ThresholdVariable = types.StringValue(va.String())
-				} else if t.String() == "global" {
-					data.Ipv4Neighbors[i].AddressFamilies[ci].Threshold = types.Int64Value(va.Int())
-				}
-			}
 			data.Ipv4Neighbors[i].AddressFamilies[ci].PolicyType = types.StringNull()
 
 			if t := cr.Get("maxPrefixConfig.policyType.optionType"); t.Exists() {
 				va := cr.Get("maxPrefixConfig.policyType.value")
 				if t.String() == "global" {
 					data.Ipv4Neighbors[i].AddressFamilies[ci].PolicyType = types.StringValue(va.String())
+				}
+			}
+			data.Ipv4Neighbors[i].AddressFamilies[ci].RestartMaxNumberOfPrefixes = types.Int64Null()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].RestartMaxNumberOfPrefixesVariable = types.StringNull()
+			if t := cr.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
+				va := cr.Get("maxPrefixConfig.prefixNum.value")
+				if t.String() == "variable" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].RestartMaxNumberOfPrefixesVariable = types.StringValue(va.String())
+				} else if t.String() == "global" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].RestartMaxNumberOfPrefixes = types.Int64Value(va.Int())
+				}
+			}
+			data.Ipv4Neighbors[i].AddressFamilies[ci].RestartThreshold = types.Int64Null()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].RestartThresholdVariable = types.StringNull()
+			if t := cr.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
+				va := cr.Get("maxPrefixConfig.threshold.value")
+				if t.String() == "variable" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].RestartThresholdVariable = types.StringValue(va.String())
+				} else if t.String() == "global" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].RestartThreshold = types.Int64Value(va.Int())
 				}
 			}
 			data.Ipv4Neighbors[i].AddressFamilies[ci].RestartInterval = types.Int64Null()
@@ -2825,6 +2931,46 @@ func (data *TransportRoutingBGP) updateFromBody(ctx context.Context, res gjson.R
 					data.Ipv4Neighbors[i].AddressFamilies[ci].RestartIntervalVariable = types.StringValue(va.String())
 				} else if t.String() == "global" {
 					data.Ipv4Neighbors[i].AddressFamilies[ci].RestartInterval = types.Int64Value(va.Int())
+				}
+			}
+			data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageMaxNumberOfPrefixes = types.Int64Null()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageMaxNumberOfPrefixesVariable = types.StringNull()
+			if t := cr.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
+				va := cr.Get("maxPrefixConfig.prefixNum.value")
+				if t.String() == "variable" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageMaxNumberOfPrefixesVariable = types.StringValue(va.String())
+				} else if t.String() == "global" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageMaxNumberOfPrefixes = types.Int64Value(va.Int())
+				}
+			}
+			data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageThreshold = types.Int64Null()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageThresholdVariable = types.StringNull()
+			if t := cr.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
+				va := cr.Get("maxPrefixConfig.threshold.value")
+				if t.String() == "variable" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageThresholdVariable = types.StringValue(va.String())
+				} else if t.String() == "global" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].WarningMessageThreshold = types.Int64Value(va.Int())
+				}
+			}
+			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMaxNumberOfPrefixes = types.Int64Null()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMaxNumberOfPrefixesVariable = types.StringNull()
+			if t := cr.Get("maxPrefixConfig.prefixNum.optionType"); t.Exists() {
+				va := cr.Get("maxPrefixConfig.prefixNum.value")
+				if t.String() == "variable" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMaxNumberOfPrefixesVariable = types.StringValue(va.String())
+				} else if t.String() == "global" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMaxNumberOfPrefixes = types.Int64Value(va.Int())
+				}
+			}
+			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThreshold = types.Int64Null()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThresholdVariable = types.StringNull()
+			if t := cr.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
+				va := cr.Get("maxPrefixConfig.threshold.value")
+				if t.String() == "variable" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThresholdVariable = types.StringValue(va.String())
+				} else if t.String() == "global" {
+					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThreshold = types.Int64Value(va.Int())
 				}
 			}
 			data.Ipv4Neighbors[i].AddressFamilies[ci].InRoutePolicyId = types.StringNull()

--- a/internal/provider/model_sdwan_transport_routing_bgp_feature.go
+++ b/internal/provider/model_sdwan_transport_routing_bgp_feature.go
@@ -225,8 +225,8 @@ type TransportRoutingBGPIpv4NeighborsAddressFamilies struct {
 	WarningMessageThresholdVariable           types.String `tfsdk:"warning_message_threshold_variable"`
 	DisablePeerMaxNumberOfPrefixes            types.Int64  `tfsdk:"disable_peer_max_number_of_prefixes"`
 	DisablePeerMaxNumberOfPrefixesVariable    types.String `tfsdk:"disable_peer_max_number_of_prefixes_variable"`
-	DisablePeerMessageThreshold               types.Int64  `tfsdk:"disable_peer_message_threshold"`
-	DisablePeerMessageThresholdVariable       types.String `tfsdk:"disable_peer_message_threshold_variable"`
+	DisablePeerThreshold                      types.Int64  `tfsdk:"disable_peer_threshold"`
+	DisablePeerThresholdVariable              types.String `tfsdk:"disable_peer_threshold_variable"`
 	InRoutePolicyId                           types.String `tfsdk:"in_route_policy_id"`
 	OutRoutePolicyId                          types.String `tfsdk:"out_route_policy_id"`
 }
@@ -875,12 +875,12 @@ func (data TransportRoutingBGP) toBody(ctx context.Context) string {
 						}
 					}
 
-					if !childItem.DisablePeerMessageThresholdVariable.IsNull() {
+					if !childItem.DisablePeerThresholdVariable.IsNull() {
 						if true && childItem.PolicyType.ValueString() == "disable-peer" {
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "variable")
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.DisablePeerMessageThresholdVariable.ValueString())
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.DisablePeerThresholdVariable.ValueString())
 						}
-					} else if childItem.DisablePeerMessageThreshold.IsNull() {
+					} else if childItem.DisablePeerThreshold.IsNull() {
 						if true && childItem.PolicyType.ValueString() == "disable-peer" {
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "default")
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", 75)
@@ -888,7 +888,7 @@ func (data TransportRoutingBGP) toBody(ctx context.Context) string {
 					} else {
 						if true && childItem.PolicyType.ValueString() == "disable-peer" {
 							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.optionType", "global")
-							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.DisablePeerMessageThreshold.ValueInt64())
+							itemChildBody, _ = sjson.Set(itemChildBody, "maxPrefixConfig.threshold.value", childItem.DisablePeerThreshold.ValueInt64())
 						}
 					}
 					if !childItem.InRoutePolicyId.IsNull() {
@@ -1984,14 +1984,14 @@ func (data *TransportRoutingBGP) fromBody(ctx context.Context, res gjson.Result)
 							cItem.DisablePeerMaxNumberOfPrefixes = types.Int64Value(va.Int())
 						}
 					}
-					cItem.DisablePeerMessageThreshold = types.Int64Null()
-					cItem.DisablePeerMessageThresholdVariable = types.StringNull()
+					cItem.DisablePeerThreshold = types.Int64Null()
+					cItem.DisablePeerThresholdVariable = types.StringNull()
 					if t := cv.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
 						va := cv.Get("maxPrefixConfig.threshold.value")
 						if t.String() == "variable" {
-							cItem.DisablePeerMessageThresholdVariable = types.StringValue(va.String())
+							cItem.DisablePeerThresholdVariable = types.StringValue(va.String())
 						} else if t.String() == "global" {
-							cItem.DisablePeerMessageThreshold = types.Int64Value(va.Int())
+							cItem.DisablePeerThreshold = types.Int64Value(va.Int())
 						}
 					}
 					cItem.InRoutePolicyId = types.StringNull()
@@ -2963,14 +2963,14 @@ func (data *TransportRoutingBGP) updateFromBody(ctx context.Context, res gjson.R
 					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMaxNumberOfPrefixes = types.Int64Value(va.Int())
 				}
 			}
-			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThreshold = types.Int64Null()
-			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThresholdVariable = types.StringNull()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerThreshold = types.Int64Null()
+			data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerThresholdVariable = types.StringNull()
 			if t := cr.Get("maxPrefixConfig.threshold.optionType"); t.Exists() {
 				va := cr.Get("maxPrefixConfig.threshold.value")
 				if t.String() == "variable" {
-					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThresholdVariable = types.StringValue(va.String())
+					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerThresholdVariable = types.StringValue(va.String())
 				} else if t.String() == "global" {
-					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerMessageThreshold = types.Int64Value(va.Int())
+					data.Ipv4Neighbors[i].AddressFamilies[ci].DisablePeerThreshold = types.Int64Value(va.Int())
 				}
 			}
 			data.Ipv4Neighbors[i].AddressFamilies[ci].InRoutePolicyId = types.StringNull()

--- a/internal/provider/resource_sdwan_transport_routing_bgp_feature.go
+++ b/internal/provider/resource_sdwan_transport_routing_bgp_feature.go
@@ -455,14 +455,14 @@ func (r *TransportRoutingBGPProfileParcelResource) Schema(ctx context.Context, r
 										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`").String,
 										Optional:            true,
 									},
-									"disable_peer_message_threshold": schema.Int64Attribute{
+									"disable_peer_threshold": schema.Int64Attribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `disable-peer`").AddIntegerRangeDescription(1, 100).AddDefaultValueDescription("75").String,
 										Optional:            true,
 										Validators: []validator.Int64{
 											int64validator.Between(1, 100),
 										},
 									},
-									"disable_peer_message_threshold_variable": schema.StringAttribute{
+									"disable_peer_threshold_variable": schema.StringAttribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`").String,
 										Optional:            true,
 									},

--- a/internal/provider/resource_sdwan_transport_routing_bgp_feature.go
+++ b/internal/provider/resource_sdwan_transport_routing_bgp_feature.go
@@ -382,41 +382,88 @@ func (r *TransportRoutingBGPProfileParcelResource) Schema(ctx context.Context, r
 											stringvalidator.OneOf("ipv4-unicast", "vpnv4-unicast", "vpnv6-unicast"),
 										},
 									},
-									"max_number_of_prefixes": schema.Int64Attribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Set maximum number of prefixes accepted from BGP peer").AddIntegerRangeDescription(1, 4294967295).String,
+									"policy_type": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Neighbor received maximum prefix policy is disabled.").AddStringEnumDescription("restart", "off", "warning-only", "disable-peer").String,
+										Optional:            true,
+										Validators: []validator.String{
+											stringvalidator.OneOf("restart", "off", "warning-only", "disable-peer"),
+										},
+									},
+									"restart_max_number_of_prefixes": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Set maximum number of prefixes accepted from BGP peer, Attribute conditional on `policy_type` being equal to `restart`").AddIntegerRangeDescription(1, 4294967295).String,
 										Optional:            true,
 										Validators: []validator.Int64{
 											int64validator.Between(1, 4294967295),
 										},
 									},
-									"max_number_of_prefixes_variable": schema.StringAttribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+									"restart_max_number_of_prefixes_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `restart`").String,
 										Optional:            true,
 									},
-									"threshold": schema.Int64Attribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Set threshold(1 to 100) at which to generate a warning message").AddIntegerRangeDescription(1, 100).AddDefaultValueDescription("75").String,
+									"restart_threshold": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `restart`").AddIntegerRangeDescription(1, 100).AddDefaultValueDescription("75").String,
 										Optional:            true,
 										Validators: []validator.Int64{
 											int64validator.Between(1, 100),
 										},
 									},
-									"threshold_variable": schema.StringAttribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
-										Optional:            true,
-									},
-									"policy_type": schema.StringAttribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Neighbor received maximum prefix policy is disabled.").String,
+									"restart_threshold_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `restart`").String,
 										Optional:            true,
 									},
 									"restart_interval": schema.Int64Attribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Set the restart interval(minutes) when to restart BGP connection if threshold is exceeded").AddIntegerRangeDescription(1, 65535).String,
+										MarkdownDescription: helpers.NewAttributeDescription("Set the restart interval(minutes) when to restart BGP connection if threshold is exceeded, Attribute conditional on `policy_type` being equal to `restart`").AddIntegerRangeDescription(1, 65535).String,
 										Optional:            true,
 										Validators: []validator.Int64{
 											int64validator.Between(1, 65535),
 										},
 									},
 									"restart_interval_variable": schema.StringAttribute{
-										MarkdownDescription: helpers.NewAttributeDescription("Variable name").String,
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `restart`").String,
+										Optional:            true,
+									},
+									"warning_message_max_number_of_prefixes": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Set maximum number of prefixes accepted from BGP peer, Attribute conditional on `policy_type` being equal to `warning-only`").AddIntegerRangeDescription(1, 4294967295).String,
+										Optional:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(1, 4294967295),
+										},
+									},
+									"warning_message_max_number_of_prefixes_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `warning-only`").String,
+										Optional:            true,
+									},
+									"warning_message_threshold": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `warning-only`").AddIntegerRangeDescription(1, 100).AddDefaultValueDescription("75").String,
+										Optional:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(1, 100),
+										},
+									},
+									"warning_message_threshold_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `warning-only`").String,
+										Optional:            true,
+									},
+									"disable_peer_max_number_of_prefixes": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Set maximum number of prefixes accepted from BGP peer, Attribute conditional on `policy_type` being equal to `disable-peer`").AddIntegerRangeDescription(1, 4294967295).String,
+										Optional:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(1, 4294967295),
+										},
+									},
+									"disable_peer_max_number_of_prefixes_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`").String,
+										Optional:            true,
+									},
+									"disable_peer_message_threshold": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Set threshold(1 to 100) at which to generate a warning message, Attribute conditional on `policy_type` being equal to `disable-peer`").AddIntegerRangeDescription(1, 100).AddDefaultValueDescription("75").String,
+										Optional:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(1, 100),
+										},
+									},
+									"disable_peer_message_threshold_variable": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Variable name, Attribute conditional on `policy_type` being equal to `disable-peer`").String,
 										Optional:            true,
 									},
 									"in_route_policy_id": schema.StringAttribute{

--- a/internal/provider/resource_sdwan_transport_routing_bgp_feature_test.go
+++ b/internal/provider/resource_sdwan_transport_routing_bgp_feature_test.go
@@ -64,9 +64,9 @@ func TestAccSdwanTransportRoutingBGPProfileParcel(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.as_override", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.allowas_in_number", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.family_type", "ipv4-unicast"))
-	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.max_number_of_prefixes", "2000"))
-	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.threshold", "75"))
 	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.policy_type", "restart"))
+	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.restart_max_number_of_prefixes", "2000"))
+	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.restart_threshold", "75"))
 	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv4_neighbors.0.address_families.0.restart_interval", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv6_neighbors.0.address", "2001::1"))
 	checks = append(checks, resource.TestCheckResourceAttr("sdwan_transport_routing_bgp_feature.test", "ipv6_neighbors.0.description", "neighbor2"))
@@ -184,9 +184,9 @@ func testAccSdwanTransportRoutingBGPProfileParcelConfig_all() string {
 	config += `	  allowas_in_number = 1` + "\n"
 	config += `	  address_families = [{` + "\n"
 	config += `		family_type = "ipv4-unicast"` + "\n"
-	config += `		max_number_of_prefixes = 2000` + "\n"
-	config += `		threshold = 75` + "\n"
 	config += `		policy_type = "restart"` + "\n"
+	config += `		restart_max_number_of_prefixes = 2000` + "\n"
+	config += `		restart_threshold = 75` + "\n"
 	config += `		restart_interval = 30` + "\n"
 	config += `	}]` + "\n"
 	config += `	}]` + "\n"


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Resolves issue #413 by separating `prefixNum` and `threshold` to be `policyType` specific. For example, `restart_threshold`, `warning_message_threshold`, and `disable_peer_threshold`. This is a work around to prevent the need to refactor the conditional attributes functionality to support multiple values. 

Let me know what you think about this implementation or if you would prefer this to be reworked further. 

### Types of Changes
<!-- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Build/CI change
* [ ] Code quality improvement/refactoring/documentation (no functional changes)

### Checklist
<!-- Go over all of the following points, and put an x in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] My code follows the code style of this project
* [x] I have added tests to cover my changes
* [x] All new and existing tests pass locally