### PR TITLE
Fix incorrect field name for translatedSourceIp 

### DIFF
--- a/internal/provider/model_sdwan_service_lan_vpn_feature.go
+++ b/internal/provider/model_sdwan_service_lan_vpn_feature.go
@@ -1205,13 +1205,13 @@ func (data ServiceLANVPN) toBody(ctx context.Context) string {
 
 			if !item.TranslatedSourceIpVariable.IsNull() {
 				if true {
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.optionType", "variable")
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.value", item.TranslatedSourceIpVariable.ValueString())
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.optionType", "variable")
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.value", item.TranslatedSourceIpVariable.ValueString())
 				}
 			} else if !item.TranslatedSourceIp.IsNull() {
 				if true {
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.optionType", "global")
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.value", item.TranslatedSourceIp.ValueString())
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.optionType", "global")
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.value", item.TranslatedSourceIp.ValueString())
 				}
 			}
 
@@ -1265,13 +1265,13 @@ func (data ServiceLANVPN) toBody(ctx context.Context) string {
 
 			if !item.TranslatedSourceIpVariable.IsNull() {
 				if true {
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.optionType", "variable")
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.value", item.TranslatedSourceIpVariable.ValueString())
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.optionType", "variable")
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.value", item.TranslatedSourceIpVariable.ValueString())
 				}
 			} else if !item.TranslatedSourceIp.IsNull() {
 				if true {
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.optionType", "global")
-					itemBody, _ = sjson.Set(itemBody, "TranslatedSourceIp.value", item.TranslatedSourceIp.ValueString())
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.optionType", "global")
+					itemBody, _ = sjson.Set(itemBody, "translatedSourceIp.value", item.TranslatedSourceIp.ValueString())
 				}
 			}
 
@@ -2327,8 +2327,8 @@ func (data *ServiceLANVPN) fromBody(ctx context.Context, res gjson.Result) {
 			}
 			item.TranslatedSourceIp = types.StringNull()
 			item.TranslatedSourceIpVariable = types.StringNull()
-			if t := v.Get("TranslatedSourceIp.optionType"); t.Exists() {
-				va := v.Get("TranslatedSourceIp.value")
+			if t := v.Get("translatedSourceIp.optionType"); t.Exists() {
+				va := v.Get("translatedSourceIp.value")
 				if t.String() == "variable" {
 					item.TranslatedSourceIpVariable = types.StringValue(va.String())
 				} else if t.String() == "global" {
@@ -2375,8 +2375,8 @@ func (data *ServiceLANVPN) fromBody(ctx context.Context, res gjson.Result) {
 			}
 			item.TranslatedSourceIp = types.StringNull()
 			item.TranslatedSourceIpVariable = types.StringNull()
-			if t := v.Get("TranslatedSourceIp.optionType"); t.Exists() {
-				va := v.Get("TranslatedSourceIp.value")
+			if t := v.Get("translatedSourceIp.optionType"); t.Exists() {
+				va := v.Get("translatedSourceIp.value")
 				if t.String() == "variable" {
 					item.TranslatedSourceIpVariable = types.StringValue(va.String())
 				} else if t.String() == "global" {
@@ -3811,8 +3811,8 @@ func (data *ServiceLANVPN) updateFromBody(ctx context.Context, res gjson.Result)
 		}
 		data.NatPortForwards[i].TranslatedSourceIp = types.StringNull()
 		data.NatPortForwards[i].TranslatedSourceIpVariable = types.StringNull()
-		if t := r.Get("TranslatedSourceIp.optionType"); t.Exists() {
-			va := r.Get("TranslatedSourceIp.value")
+		if t := r.Get("translatedSourceIp.optionType"); t.Exists() {
+			va := r.Get("translatedSourceIp.value")
 			if t.String() == "variable" {
 				data.NatPortForwards[i].TranslatedSourceIpVariable = types.StringValue(va.String())
 			} else if t.String() == "global" {
@@ -3883,8 +3883,8 @@ func (data *ServiceLANVPN) updateFromBody(ctx context.Context, res gjson.Result)
 		}
 		data.StaticNats[i].TranslatedSourceIp = types.StringNull()
 		data.StaticNats[i].TranslatedSourceIpVariable = types.StringNull()
-		if t := r.Get("TranslatedSourceIp.optionType"); t.Exists() {
-			va := r.Get("TranslatedSourceIp.value")
+		if t := r.Get("translatedSourceIp.optionType"); t.Exists() {
+			va := r.Get("translatedSourceIp.value")
 			if t.String() == "variable" {
 				data.StaticNats[i].TranslatedSourceIpVariable = types.StringValue(va.String())
 			} else if t.String() == "global" {


### PR DESCRIPTION
Hi,

I encountered an error when trying to configure the nat_port_forwards block.
After reviewing the code, I noticed that the field translatedSourceIp was mistakenly written as TranslatedSourceIp.
It works fine after i changed it to translatedSourceIp in my local environment.

This PR corrects the casing to align with the expected schema.

Thanks for your work on this provider!

 
  ~ resource "sdwan_service_lan_vpn_feature" "service_lan_vpn_feature" {
        id                         = "e844da94-eaf1-438b-9a52-4a786377091c"
        name                       = "DC-LAN-VPN-10"
      + nat_port_forwards          = [
          + {
              + nat_pool_name        = 1
              + protocol             = "TCP"
              + source_ip            = "10.1.1.100"
              + source_port          = 80
              + translate_port       = 8080
              + **translated_source_ip** = "203.0.113.10"
            },
        ]
      ~ version                    = 0 -> (known after apply)
        # (14 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.sdwan.sdwan_service_lan_vpn_feature.service_lan_vpn_feature["service-profile-datacenter-DC-LAN-VPN-10"]: Modifying... [id=e844da94-eaf1-438b-9a52-4a786377091c]
╷
│ Error: Client Error
│ 
│   with module.sdwan.sdwan_service_lan_vpn_feature.service_lan_vpn_feature["service-profile-datacenter-DC-LAN-VPN-10"],
│   on .terraform/modules/sdwan/sdwan_features_service.tf line 161, in resource "sdwan_service_lan_vpn_feature" "service_lan_vpn_feature":
│  161: resource "sdwan_service_lan_vpn_feature" "service_lan_vpn_feature" {
│ 
│ Failed to configure object (PUT), got error: HTTP Request failed: StatusCode 400, {"error":{"message":"Invalid Json Payload Input","code":"SCHVALID0001","details":"{\"Validation Errors\":{\"Required But Missing
│ Attributes\":[\"data.natPortForward[0].**translatedSourceIp**\"],\"Not Defined In Schema Attributes\":[\"data.natPortForward[0].**TranslatedSourceIp**\"]}}","type":"error"}}