### PR TITLE
[UX2.0] Resolve issue #495 

### DIFF
--- a/gen/definitions/generic/preferred_color_group_policy_object.yaml
+++ b/gen/definitions/generic/preferred_color_group_policy_object.yaml
@@ -1,3 +1,4 @@
+# Manual resource - 
 ---
 name: Preferred Color Group Policy Object
 rest_endpoint: /template/policy/list/preferredcolorgroup/

--- a/internal/provider/model_sdwan_policy_object_preferred_color_group.go
+++ b/internal/provider/model_sdwan_policy_object_preferred_color_group.go
@@ -66,7 +66,6 @@ func (data PolicyObjectPreferredColorGroup) getPath() string {
 
 // End of section. //template:end getPath
 
-// Section below is generated&owned by "gen/generator.go". //template:begin toBody
 func (data PolicyObjectPreferredColorGroup) toBody(ctx context.Context) string {
 	body := ""
 	body, _ = sjson.Set(body, "name", data.Name.ValueString())
@@ -76,7 +75,9 @@ func (data PolicyObjectPreferredColorGroup) toBody(ctx context.Context) string {
 
 		for _, item := range data.Entries {
 			itemBody := ""
-			if !item.PrimaryColorPreference.IsNull() {
+			if item.PrimaryColorPreference.IsNull() {
+				itemBody, _ = sjson.Set(itemBody, "primaryPreference", map[string]interface{}{})
+			} else {
 				if true {
 					itemBody, _ = sjson.Set(itemBody, "primaryPreference.colorPreference.optionType", "global")
 					var values []string
@@ -90,7 +91,9 @@ func (data PolicyObjectPreferredColorGroup) toBody(ctx context.Context) string {
 					itemBody, _ = sjson.Set(itemBody, "primaryPreference.pathPreference.value", item.PrimaryPathPreference.ValueString())
 				}
 			}
-			if !item.SecondaryColorPreference.IsNull() {
+			if item.SecondaryColorPreference.IsNull() {
+				itemBody, _ = sjson.Set(itemBody, "secondaryPreference", map[string]interface{}{})
+			} else {
 				if true {
 					itemBody, _ = sjson.Set(itemBody, "secondaryPreference.colorPreference.optionType", "global")
 					var values []string
@@ -104,7 +107,9 @@ func (data PolicyObjectPreferredColorGroup) toBody(ctx context.Context) string {
 					itemBody, _ = sjson.Set(itemBody, "secondaryPreference.pathPreference.value", item.SecondaryPathPreference.ValueString())
 				}
 			}
-			if !item.TertiaryColorPreference.IsNull() {
+			if item.TertiaryColorPreference.IsNull() {
+				itemBody, _ = sjson.Set(itemBody, "tertiaryPreference", map[string]interface{}{})
+			} else {
 				if true {
 					itemBody, _ = sjson.Set(itemBody, "tertiaryPreference.colorPreference.optionType", "global")
 					var values []string
@@ -123,8 +128,6 @@ func (data PolicyObjectPreferredColorGroup) toBody(ctx context.Context) string {
 	}
 	return body
 }
-
-// End of section. //template:end toBody
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBody
 func (data *PolicyObjectPreferredColorGroup) fromBody(ctx context.Context, res gjson.Result) {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

 Convert `sdwan_policy_object_preferred_color_group` to be a manual resource to support empty interface when no value is included for `secondary_color_preference` and `tertiary_color_preference`, Resolving issue #495 

### Types of Changes
<!-- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Build/CI change
* [ ] Code quality improvement/refactoring/documentation (no functional changes)

### Checklist
<!-- Go over all of the following points, and put an x in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] My code follows the code style of this project
* [x] I have added tests to cover my changes
* [x] All new and existing tests pass locally