### PR TITLE
Fix type issues with using `sdwan_security_policy` in unified mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - BREAKING CHANGE: Fix type of `imcp_unreachable_allow`, `session_reclassify_allow`, and `unified_logging` in `sdwan_security_policy` resource and data source
 - BREAKING CHANGE: Fix type of `max_incomplete_icmp_limit`, `max_incomplete_tcp_limit`, and `max_incomplete_upd_limit` in `sdwan_security_policy` resource and data source
 - BREAKING CHANGE: Converts `source_zone` and `destination_zone` fields to `entries` list containing `source_zone`/`destination_zone` objects to support multiple entries in `sdwan_security_policy` resource and data source
-- Adds `high_speed_logging_entries` support to the `sdwan_security_policy` resource and data source
 
 ## 0.7.1
 

--- a/docs/data-sources/security_policy.md
+++ b/docs/data-sources/security_policy.md
@@ -32,9 +32,9 @@ data "sdwan_security_policy" "example" {
 - `description` (String) The description of the security policy
 - `direct_internet_applications` (String) Bypass firewall policy and allow all Internet traffic to/from VPN 0
 - `failure_mode` (String) Failure mode
-- `high_speed_logging_entries` (Attributes List) High Speed Logging Entries (see [below for nested schema](#nestedatt--high_speed_logging_entries))
 - `high_speed_logging_server_ip` (String) High Speed Logging Server IP
 - `high_speed_logging_server_port` (String) High Speed Logging Port
+- `high_speed_logging_server_source_interface` (String) High Speed Logging Source Interface
 - `high_speed_logging_vpn` (String) High Speed Logging VPN
 - `imcp_unreachable_allow` (String) ICMP Unreachable Allow
 - `logging` (Attributes List) (see [below for nested schema](#nestedatt--logging))
@@ -68,17 +68,6 @@ Read-Only:
 - `destination_zone` (String) Destination Zone
 - `source_zone` (String) Source Zone
 
-
-
-<a id="nestedatt--high_speed_logging_entries"></a>
-### Nested Schema for `high_speed_logging_entries`
-
-Read-Only:
-
-- `port` (String) High Speed Logging Port
-- `server_ip` (String) High Speed Logging Server IP
-- `source_interface` (String) High Speed Logging Source Interface
-- `vpn` (String) High Speed Logging VPN
 
 
 <a id="nestedatt--logging"></a>

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -16,7 +16,6 @@ description: |-
 - BREAKING CHANGE: Fix type of `imcp_unreachable_allow`, `session_reclassify_allow`, and `unified_logging` in `sdwan_security_policy` resource and data source
 - BREAKING CHANGE: Fix type of `max_incomplete_icmp_limit`, `max_incomplete_tcp_limit`, and `max_incomplete_upd_limit` in `sdwan_security_policy` resource and data source
 - BREAKING CHANGE: Converts `source_zone` and `destination_zone` fields to `entries` list containing `source_zone`/`destination_zone` objects to support multiple entries in `sdwan_security_policy` resource and data source
-- Adds `high_speed_logging_entries` support to the `sdwan_security_policy` resource and data source
 
 ## 0.7.1
 

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -51,10 +51,10 @@ resource "sdwan_security_policy" "example" {
   - Choices: `allow`, `deny`
 - `failure_mode` (String) Failure mode
   - Choices: `open`, `close`
-- `high_speed_logging_entries` (Attributes List) High Speed Logging Entries, Attribute conditional on `mode` being equal to `unified` (see [below for nested schema](#nestedatt--high_speed_logging_entries))
-- `high_speed_logging_server_ip` (String) High Speed Logging Server IP, Attribute conditional on `mode` being equal to `security`
-- `high_speed_logging_server_port` (String) High Speed Logging Port, Attribute conditional on `mode` being equal to `security`
-- `high_speed_logging_vpn` (String) High Speed Logging VPN, Attribute conditional on `mode` being equal to `security`
+- `high_speed_logging_server_ip` (String) High Speed Logging Server IP
+- `high_speed_logging_server_port` (String) High Speed Logging Port
+- `high_speed_logging_server_source_interface` (String) High Speed Logging Source Interface
+- `high_speed_logging_vpn` (String) High Speed Logging VPN
 - `imcp_unreachable_allow` (String) ICMP Unreachable Allow
   - Choices: `on`, `off`
 - `logging` (Attributes List) (see [below for nested schema](#nestedatt--logging))
@@ -102,17 +102,6 @@ Optional:
 - `destination_zone` (String) Destination Zone
 - `source_zone` (String) Source Zone
 
-
-
-<a id="nestedatt--high_speed_logging_entries"></a>
-### Nested Schema for `high_speed_logging_entries`
-
-Optional:
-
-- `port` (String) High Speed Logging Port
-- `server_ip` (String) High Speed Logging Server IP
-- `source_interface` (String) High Speed Logging Source Interface
-- `vpn` (String) High Speed Logging VPN
 
 
 <a id="nestedatt--logging"></a>

--- a/gen/definitions/generic/security_policy.yaml
+++ b/gen/definitions/generic/security_policy.yaml
@@ -148,9 +148,6 @@ attributes:
     description: High Speed Logging Server IP
     example: 10.0.0.1
     exclude_test: true
-    conditional_attribute:
-      name: mode
-      value: security
   - model_name: vrf
     data_path: [policyDefinition, settings, highSpeedLogging]
     tf_name: high_speed_logging_vpn
@@ -158,9 +155,6 @@ attributes:
     description: High Speed Logging VPN
     example: 123
     exclude_test: true
-    conditional_attribute:
-      name: mode
-      value: security
   - model_name: port
     data_path: [policyDefinition, settings, highSpeedLogging]
     tf_name: high_speed_logging_server_port
@@ -168,43 +162,13 @@ attributes:
     description: High Speed Logging Port
     example: 2055
     exclude_test: true
-    conditional_attribute:
-      name: mode
-      value: security
-  - model_name: entries
-    tf_name: high_speed_logging_entries
+  - model_name: sourceInterface
     data_path: [policyDefinition, settings, highSpeedLogging]
+    tf_name: high_speed_logging_server_source_interface
+    type: String
+    description: High Speed Logging Source Interface
+    example: Loopback
     exclude_test: true
-    type: List
-    description: High Speed Logging Entries
-    conditional_attribute:
-      name: mode
-      value: unified
-    attributes:
-    - model_name: serverIp
-      tf_name: server_ip
-      type: String
-      description: High Speed Logging Server IP
-      example: 10.0.0.1
-      exclude_test: true
-    - model_name: vrf
-      tf_name: vpn
-      type: String
-      description: High Speed Logging VPN
-      example: 123
-      exclude_test: true
-    - model_name: port
-      tf_name: port
-      type: String
-      description: High Speed Logging Port
-      example: 2055
-      exclude_test: true
-    - model_name: sourceInterface
-      tf_name: source_interface
-      type: String
-      description: High Speed Logging Source Interface
-      example: Loopback
-      exclude_test: true
   - model_name: maxIncompleteIcmpLimit
     data_path: [policyDefinition, settings]
     tf_name: max_incomplete_icmp_limit

--- a/internal/provider/data_source_sdwan_security_policy.go
+++ b/internal/provider/data_source_sdwan_security_policy.go
@@ -149,29 +149,9 @@ func (d *SecurityPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				MarkdownDescription: "High Speed Logging Port",
 				Computed:            true,
 			},
-			"high_speed_logging_entries": schema.ListNestedAttribute{
-				MarkdownDescription: "High Speed Logging Entries",
+			"high_speed_logging_server_source_interface": schema.StringAttribute{
+				MarkdownDescription: "High Speed Logging Source Interface",
 				Computed:            true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"server_ip": schema.StringAttribute{
-							MarkdownDescription: "High Speed Logging Server IP",
-							Computed:            true,
-						},
-						"vpn": schema.StringAttribute{
-							MarkdownDescription: "High Speed Logging VPN",
-							Computed:            true,
-						},
-						"port": schema.StringAttribute{
-							MarkdownDescription: "High Speed Logging Port",
-							Computed:            true,
-						},
-						"source_interface": schema.StringAttribute{
-							MarkdownDescription: "High Speed Logging Source Interface",
-							Computed:            true,
-						},
-					},
-				},
 			},
 			"max_incomplete_icmp_limit": schema.StringAttribute{
 				MarkdownDescription: "Max Incomplete ICMP Limit",

--- a/internal/provider/model_sdwan_security_policy.go
+++ b/internal/provider/model_sdwan_security_policy.go
@@ -31,29 +31,29 @@ import (
 
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 type SecurityPolicy struct {
-	Id                         types.String                            `tfsdk:"id"`
-	Version                    types.Int64                             `tfsdk:"version"`
-	Name                       types.String                            `tfsdk:"name"`
-	Description                types.String                            `tfsdk:"description"`
-	Mode                       types.String                            `tfsdk:"mode"`
-	UseCase                    types.String                            `tfsdk:"use_case"`
-	Definitions                []SecurityPolicyDefinitions             `tfsdk:"definitions"`
-	DirectInternetApplications types.String                            `tfsdk:"direct_internet_applications"`
-	TcpSynFloodLimit           types.String                            `tfsdk:"tcp_syn_flood_limit"`
-	AuditTrail                 types.String                            `tfsdk:"audit_trail"`
-	MatchStatisticsPerFilter   types.String                            `tfsdk:"match_statistics_per_filter"`
-	FailureMode                types.String                            `tfsdk:"failure_mode"`
-	HighSpeedLoggingServerIp   types.String                            `tfsdk:"high_speed_logging_server_ip"`
-	HighSpeedLoggingVpn        types.String                            `tfsdk:"high_speed_logging_vpn"`
-	HighSpeedLoggingServerPort types.String                            `tfsdk:"high_speed_logging_server_port"`
-	HighSpeedLoggingEntries    []SecurityPolicyHighSpeedLoggingEntries `tfsdk:"high_speed_logging_entries"`
-	MaxIncompleteIcmpLimit     types.String                            `tfsdk:"max_incomplete_icmp_limit"`
-	MaxIncompleteTcpLimit      types.String                            `tfsdk:"max_incomplete_tcp_limit"`
-	MaxIncompleteUdpLimit      types.String                            `tfsdk:"max_incomplete_udp_limit"`
-	SessionReclassifyAllow     types.String                            `tfsdk:"session_reclassify_allow"`
-	ImcpUnreachableAllow       types.String                            `tfsdk:"imcp_unreachable_allow"`
-	UnifiedLogging             types.String                            `tfsdk:"unified_logging"`
-	Logging                    []SecurityPolicyLogging                 `tfsdk:"logging"`
+	Id                                    types.String                `tfsdk:"id"`
+	Version                               types.Int64                 `tfsdk:"version"`
+	Name                                  types.String                `tfsdk:"name"`
+	Description                           types.String                `tfsdk:"description"`
+	Mode                                  types.String                `tfsdk:"mode"`
+	UseCase                               types.String                `tfsdk:"use_case"`
+	Definitions                           []SecurityPolicyDefinitions `tfsdk:"definitions"`
+	DirectInternetApplications            types.String                `tfsdk:"direct_internet_applications"`
+	TcpSynFloodLimit                      types.String                `tfsdk:"tcp_syn_flood_limit"`
+	AuditTrail                            types.String                `tfsdk:"audit_trail"`
+	MatchStatisticsPerFilter              types.String                `tfsdk:"match_statistics_per_filter"`
+	FailureMode                           types.String                `tfsdk:"failure_mode"`
+	HighSpeedLoggingServerIp              types.String                `tfsdk:"high_speed_logging_server_ip"`
+	HighSpeedLoggingVpn                   types.String                `tfsdk:"high_speed_logging_vpn"`
+	HighSpeedLoggingServerPort            types.String                `tfsdk:"high_speed_logging_server_port"`
+	HighSpeedLoggingServerSourceInterface types.String                `tfsdk:"high_speed_logging_server_source_interface"`
+	MaxIncompleteIcmpLimit                types.String                `tfsdk:"max_incomplete_icmp_limit"`
+	MaxIncompleteTcpLimit                 types.String                `tfsdk:"max_incomplete_tcp_limit"`
+	MaxIncompleteUdpLimit                 types.String                `tfsdk:"max_incomplete_udp_limit"`
+	SessionReclassifyAllow                types.String                `tfsdk:"session_reclassify_allow"`
+	ImcpUnreachableAllow                  types.String                `tfsdk:"imcp_unreachable_allow"`
+	UnifiedLogging                        types.String                `tfsdk:"unified_logging"`
+	Logging                               []SecurityPolicyLogging     `tfsdk:"logging"`
 }
 
 type SecurityPolicyDefinitions struct {
@@ -61,13 +61,6 @@ type SecurityPolicyDefinitions struct {
 	Version types.Int64                        `tfsdk:"version"`
 	Type    types.String                       `tfsdk:"type"`
 	Entries []SecurityPolicyDefinitionsEntries `tfsdk:"entries"`
-}
-
-type SecurityPolicyHighSpeedLoggingEntries struct {
-	ServerIp        types.String `tfsdk:"server_ip"`
-	Vpn             types.String `tfsdk:"vpn"`
-	Port            types.String `tfsdk:"port"`
-	SourceInterface types.String `tfsdk:"source_interface"`
 }
 
 type SecurityPolicyLogging struct {
@@ -149,33 +142,17 @@ func (data SecurityPolicy) toBody(ctx context.Context) string {
 	if !data.FailureMode.IsNull() {
 		body, _ = sjson.Set(body, "policyDefinition.settings.failureMode", data.FailureMode.ValueString())
 	}
-	if !data.HighSpeedLoggingServerIp.IsNull() && data.Mode.ValueString() == "security" {
+	if !data.HighSpeedLoggingServerIp.IsNull() {
 		body, _ = sjson.Set(body, "policyDefinition.settings.highSpeedLogging.serverIp", data.HighSpeedLoggingServerIp.ValueString())
 	}
-	if !data.HighSpeedLoggingVpn.IsNull() && data.Mode.ValueString() == "security" {
+	if !data.HighSpeedLoggingVpn.IsNull() {
 		body, _ = sjson.Set(body, "policyDefinition.settings.highSpeedLogging.vrf", data.HighSpeedLoggingVpn.ValueString())
 	}
-	if !data.HighSpeedLoggingServerPort.IsNull() && data.Mode.ValueString() == "security" {
+	if !data.HighSpeedLoggingServerPort.IsNull() {
 		body, _ = sjson.Set(body, "policyDefinition.settings.highSpeedLogging.port", data.HighSpeedLoggingServerPort.ValueString())
 	}
-	if true && data.Mode.ValueString() == "unified" {
-		body, _ = sjson.Set(body, "policyDefinition.settings.highSpeedLogging.entries", []interface{}{})
-		for _, item := range data.HighSpeedLoggingEntries {
-			itemBody := ""
-			if !item.ServerIp.IsNull() {
-				itemBody, _ = sjson.Set(itemBody, "serverIp", item.ServerIp.ValueString())
-			}
-			if !item.Vpn.IsNull() {
-				itemBody, _ = sjson.Set(itemBody, "vrf", item.Vpn.ValueString())
-			}
-			if !item.Port.IsNull() {
-				itemBody, _ = sjson.Set(itemBody, "port", item.Port.ValueString())
-			}
-			if !item.SourceInterface.IsNull() {
-				itemBody, _ = sjson.Set(itemBody, "sourceInterface", item.SourceInterface.ValueString())
-			}
-			body, _ = sjson.SetRaw(body, "policyDefinition.settings.highSpeedLogging.entries.-1", itemBody)
-		}
+	if !data.HighSpeedLoggingServerSourceInterface.IsNull() {
+		body, _ = sjson.Set(body, "policyDefinition.settings.highSpeedLogging.sourceInterface", data.HighSpeedLoggingServerSourceInterface.ValueString())
 	}
 	if !data.MaxIncompleteIcmpLimit.IsNull() {
 		body, _ = sjson.Set(body, "policyDefinition.settings.maxIncompleteIcmpLimit", data.MaxIncompleteIcmpLimit.ValueString())
@@ -308,52 +285,25 @@ func (data *SecurityPolicy) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.FailureMode = types.StringNull()
 	}
-	if value := res.Get("policyDefinition.settings.highSpeedLogging.serverIp"); value.Exists() && data.Mode.ValueString() == "security" {
+	if value := res.Get("policyDefinition.settings.highSpeedLogging.serverIp"); value.Exists() {
 		data.HighSpeedLoggingServerIp = types.StringValue(value.String())
 	} else {
 		data.HighSpeedLoggingServerIp = types.StringNull()
 	}
-	if value := res.Get("policyDefinition.settings.highSpeedLogging.vrf"); value.Exists() && data.Mode.ValueString() == "security" {
+	if value := res.Get("policyDefinition.settings.highSpeedLogging.vrf"); value.Exists() {
 		data.HighSpeedLoggingVpn = types.StringValue(value.String())
 	} else {
 		data.HighSpeedLoggingVpn = types.StringNull()
 	}
-	if value := res.Get("policyDefinition.settings.highSpeedLogging.port"); value.Exists() && data.Mode.ValueString() == "security" {
+	if value := res.Get("policyDefinition.settings.highSpeedLogging.port"); value.Exists() {
 		data.HighSpeedLoggingServerPort = types.StringValue(value.String())
 	} else {
 		data.HighSpeedLoggingServerPort = types.StringNull()
 	}
-	if value := res.Get("policyDefinition.settings.highSpeedLogging.entries"); value.Exists() && len(value.Array()) > 0 && data.Mode.ValueString() == "unified" {
-		data.HighSpeedLoggingEntries = make([]SecurityPolicyHighSpeedLoggingEntries, 0)
-		value.ForEach(func(k, v gjson.Result) bool {
-			item := SecurityPolicyHighSpeedLoggingEntries{}
-			if cValue := v.Get("serverIp"); cValue.Exists() {
-				item.ServerIp = types.StringValue(cValue.String())
-			} else {
-				item.ServerIp = types.StringNull()
-			}
-			if cValue := v.Get("vrf"); cValue.Exists() {
-				item.Vpn = types.StringValue(cValue.String())
-			} else {
-				item.Vpn = types.StringNull()
-			}
-			if cValue := v.Get("port"); cValue.Exists() {
-				item.Port = types.StringValue(cValue.String())
-			} else {
-				item.Port = types.StringNull()
-			}
-			if cValue := v.Get("sourceInterface"); cValue.Exists() {
-				item.SourceInterface = types.StringValue(cValue.String())
-			} else {
-				item.SourceInterface = types.StringNull()
-			}
-			data.HighSpeedLoggingEntries = append(data.HighSpeedLoggingEntries, item)
-			return true
-		})
+	if value := res.Get("policyDefinition.settings.highSpeedLogging.sourceInterface"); value.Exists() {
+		data.HighSpeedLoggingServerSourceInterface = types.StringValue(value.String())
 	} else {
-		if len(data.HighSpeedLoggingEntries) > 0 {
-			data.HighSpeedLoggingEntries = []SecurityPolicyHighSpeedLoggingEntries{}
-		}
+		data.HighSpeedLoggingServerSourceInterface = types.StringNull()
 	}
 	if value := res.Get("policyDefinition.settings.maxIncompleteIcmpLimit"); value.Exists() {
 		data.MaxIncompleteIcmpLimit = types.StringValue(value.String())
@@ -480,23 +430,8 @@ func (data *SecurityPolicy) hasChanges(ctx context.Context, state *SecurityPolic
 	if !data.HighSpeedLoggingServerPort.Equal(state.HighSpeedLoggingServerPort) {
 		hasChanges = true
 	}
-	if len(data.HighSpeedLoggingEntries) != len(state.HighSpeedLoggingEntries) {
+	if !data.HighSpeedLoggingServerSourceInterface.Equal(state.HighSpeedLoggingServerSourceInterface) {
 		hasChanges = true
-	} else {
-		for i := range data.HighSpeedLoggingEntries {
-			if !data.HighSpeedLoggingEntries[i].ServerIp.Equal(state.HighSpeedLoggingEntries[i].ServerIp) {
-				hasChanges = true
-			}
-			if !data.HighSpeedLoggingEntries[i].Vpn.Equal(state.HighSpeedLoggingEntries[i].Vpn) {
-				hasChanges = true
-			}
-			if !data.HighSpeedLoggingEntries[i].Port.Equal(state.HighSpeedLoggingEntries[i].Port) {
-				hasChanges = true
-			}
-			if !data.HighSpeedLoggingEntries[i].SourceInterface.Equal(state.HighSpeedLoggingEntries[i].SourceInterface) {
-				hasChanges = true
-			}
-		}
 	}
 	if !data.MaxIncompleteIcmpLimit.Equal(state.MaxIncompleteIcmpLimit) {
 		hasChanges = true

--- a/internal/provider/resource_sdwan_security_policy.go
+++ b/internal/provider/resource_sdwan_security_policy.go
@@ -180,40 +180,20 @@ func (r *SecurityPolicyResource) Schema(ctx context.Context, req resource.Schema
 				},
 			},
 			"high_speed_logging_server_ip": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Server IP, Attribute conditional on `mode` being equal to `security`").String,
+				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Server IP").String,
 				Optional:            true,
 			},
 			"high_speed_logging_vpn": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging VPN, Attribute conditional on `mode` being equal to `security`").String,
+				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging VPN").String,
 				Optional:            true,
 			},
 			"high_speed_logging_server_port": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Port, Attribute conditional on `mode` being equal to `security`").String,
+				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Port").String,
 				Optional:            true,
 			},
-			"high_speed_logging_entries": schema.ListNestedAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Entries, Attribute conditional on `mode` being equal to `unified`").String,
+			"high_speed_logging_server_source_interface": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Source Interface").String,
 				Optional:            true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"server_ip": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Server IP").String,
-							Optional:            true,
-						},
-						"vpn": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging VPN").String,
-							Optional:            true,
-						},
-						"port": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Port").String,
-							Optional:            true,
-						},
-						"source_interface": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("High Speed Logging Source Interface").String,
-							Optional:            true,
-						},
-					},
-				},
 			},
 			"max_incomplete_icmp_limit": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Max Incomplete ICMP Limit").String,

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -16,7 +16,6 @@ description: |-
 - BREAKING CHANGE: Fix type of `imcp_unreachable_allow`, `session_reclassify_allow`, and `unified_logging` in `sdwan_security_policy` resource and data source
 - BREAKING CHANGE: Fix type of `max_incomplete_icmp_limit`, `max_incomplete_tcp_limit`, and `max_incomplete_upd_limit` in `sdwan_security_policy` resource and data source
 - BREAKING CHANGE: Converts `source_zone` and `destination_zone` fields to `entries` list containing `source_zone`/`destination_zone` objects to support multiple entries in `sdwan_security_policy` resource and data source
-- Adds `high_speed_logging_entries` support to the `sdwan_security_policy` resource and data source
 
 ## 0.7.1
 


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Fix type issues with unified security policy, specifically:
- Convert `imcp_unreachable_allow`, `session_reclassify_allow`, and `unified_logging` to type `string` with enum values of `on` or `off`
- Converts `max_incomplete_icmp_limit`, `max_incomplete_tcp_limit`, and `max_incomplete_upd_limit` to type `string`
- Converts `source_zone` and `destination_zone` fields to `entries` list containing `source_zone`/`destination_zone` objects to support multiple entries

### Types of Changes
<!-- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Build/CI change
* [ ] Code quality improvement/refactoring/documentation (no functional changes)

### Checklist
<!-- Go over all of the following points, and put an x in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] My code follows the code style of this project
* [ ] I have added tests to cover my changes
* [ ] All new and existing tests pass locally