### PR TITLE
change `definitions` attribute of `resource_sdwan_security_policy` to set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+- Change `definitions` attribute of `resource_sdwan_security_policy` resource to a set
+
 ## 0.8.0
 
 - BREAKING CHANGE: Fix type of `port` attribute of `sdwan_port_list_policy_object` to support multiple values, [Link](https://github.com/CiscoDevNet/terraform-provider-sdwan/issues/460)

--- a/docs/data-sources/security_policy.md
+++ b/docs/data-sources/security_policy.md
@@ -28,7 +28,7 @@ data "sdwan_security_policy" "example" {
 ### Read-Only
 
 - `audit_trail` (String) Audit trail
-- `definitions` (Attributes List) List of policy definitions (see [below for nested schema](#nestedatt--definitions))
+- `definitions` (Attributes Set) List of policy definitions (see [below for nested schema](#nestedatt--definitions))
 - `description` (String) The description of the security policy
 - `direct_internet_applications` (String) Bypass firewall policy and allow all Internet traffic to/from VPN 0
 - `failure_mode` (String) Failure mode

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.8.1
+
+- Change `definitions` attribute of `resource_sdwan_security_policy` resource to a set
+
 ## 0.8.0
 
 - BREAKING CHANGE: Fix type of `port` attribute of `sdwan_port_list_policy_object` to support multiple values, [Link](https://github.com/CiscoDevNet/terraform-provider-sdwan/issues/460)

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -39,7 +39,7 @@ resource "sdwan_security_policy" "example" {
 
 ### Required
 
-- `definitions` (Attributes List) List of policy definitions (see [below for nested schema](#nestedatt--definitions))
+- `definitions` (Attributes Set) List of policy definitions (see [below for nested schema](#nestedatt--definitions))
 - `description` (String) The description of the security policy
 - `name` (String) The name of the security policy
 

--- a/gen/definitions/generic/security_policy.yaml
+++ b/gen/definitions/generic/security_policy.yaml
@@ -50,7 +50,7 @@ attributes:
   - model_name: assembly
     data_path: [policyDefinition]
     tf_name: definitions
-    type: List
+    type: Set
     mandatory: true
     description: List of policy definitions
     min_list: 1

--- a/internal/provider/data_source_sdwan_security_policy.go
+++ b/internal/provider/data_source_sdwan_security_policy.go
@@ -81,7 +81,7 @@ func (d *SecurityPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				MarkdownDescription: "The use case of the security policy",
 				Computed:            true,
 			},
-			"definitions": schema.ListNestedAttribute{
+			"definitions": schema.SetNestedAttribute{
 				MarkdownDescription: "List of policy definitions",
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/resource_sdwan_security_policy.go
+++ b/internal/provider/resource_sdwan_security_policy.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 
 	"github.com/CiscoDevNet/terraform-provider-sdwan/internal/provider/helpers"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -105,7 +105,7 @@ func (r *SecurityPolicyResource) Schema(ctx context.Context, req resource.Schema
 				},
 				Default: stringdefault.StaticString("custom"),
 			},
-			"definitions": schema.ListNestedAttribute{
+			"definitions": schema.SetNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("List of policy definitions").String,
 				Required:            true,
 				NestedObject: schema.NestedAttributeObject{
@@ -143,8 +143,8 @@ func (r *SecurityPolicyResource) Schema(ctx context.Context, req resource.Schema
 						},
 					},
 				},
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
 				},
 			},
 			"direct_internet_applications": schema.StringAttribute{

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.8.1
+
+- Change `definitions` attribute of `resource_sdwan_security_policy` resource to a set
+
 ## 0.8.0
 
 - BREAKING CHANGE: Fix type of `port` attribute of `sdwan_port_list_policy_object` to support multiple values, [Link](https://github.com/CiscoDevNet/terraform-provider-sdwan/issues/460)


### PR DESCRIPTION
Aligning `resource_sdwan_security_policy` resource definitions with `resource_sdwan_localized_policy` logic. The `definitions` needs to be set as otherwise terraform shows permanent diff in every apply.