### PR TITLE
Fixes perpetual diff when topology_label is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_advanced_malware_protection` to `20.15.0`
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_tls_ssl_decryption` to `20.15.0`
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_tls_ssl_profile` to `20.15.0`
+- Fix perpetual diff in `sdwan_configuration_group` resource for `topology_label` attribute when not specified in non-dual-edge configurations
 
 ## 0.9.0
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -36,6 +36,7 @@ description: |-
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_advanced_malware_protection` to `20.15.0`
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_tls_ssl_decryption` to `20.15.0`
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_tls_ssl_profile` to `20.15.0`
+- Fix perpetual diff in `sdwan_configuration_group` resource for `topology_label` attribute when not specified in non-dual-edge configurations
 
 ## 0.9.0
 

--- a/internal/provider/model_sdwan_configuration_group.go
+++ b/internal/provider/model_sdwan_configuration_group.go
@@ -354,7 +354,7 @@ func (data *ConfigurationGroup) fromBodyConfigGroupDevices(ctx context.Context, 
 			} else {
 				item.Id = types.StringNull()
 			}
-			if cValue := v.Get("groupTopologyLabel"); cValue.Exists() {
+			if cValue := v.Get("groupTopologyLabel"); cValue.Exists() && cValue.String() != "" {
 				item.TopologyLabel = types.StringValue(cValue.String())
 			} else {
 				item.TopologyLabel = types.StringNull()

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -36,6 +36,7 @@ description: |-
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_advanced_malware_protection` to `20.15.0`
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_tls_ssl_decryption` to `20.15.0`
 - BREAKING CHANGE: Bump the minimum supported version of `sdwan_policy_object_unified_tls_ssl_profile` to `20.15.0`
+- Fix perpetual diff in `sdwan_configuration_group` resource for `topology_label` attribute when not specified in non-dual-edge configurations
 
 ## 0.9.0
 


### PR DESCRIPTION
Fixes perpetual diff when topology_label is not specified in  non-dual-edge configurations.