### PR TITLE
fix: keep topology sites/hierarchy_uuids test families mutually exclusive

### DIFF
--- a/gen/definitions/profile_parcels/topology_custom_control.yaml
+++ b/gen/definitions/profile_parcels/topology_custom_control.yaml
@@ -1,4 +1,4 @@
-# Manual tests only (model/resource still generated) - test configs keep sites/hierarchy_uuids mutually exclusive (CI sets SDWAN_2015 and SDWAN_2018 together).
+# Manual tests only (model/resource still generated) - test configs keep sites/hierarchy_uuids mutually exclusive.
 ---
 name: Topology Custom Control
 rest_endpoint: /v1/feature-profile/sdwan/topology/%v/custom-control
@@ -6,6 +6,7 @@ minimum_version: 20.15.0
 has_version: true
 id_attribute: id
 test_tags: [SDWAN_2015]
+skip_templates: ["resource_test.go", "data_source_test.go"]
 skip_minimum_test: true
 no_data_source_name_query: true
 parcel_type: feature

--- a/gen/definitions/profile_parcels/topology_hubspoke.yaml
+++ b/gen/definitions/profile_parcels/topology_hubspoke.yaml
@@ -1,4 +1,4 @@
-# Manual tests only (model/resource still generated) - test configs keep sites/hierarchy_uuids mutually exclusive (CI sets SDWAN_2015 and SDWAN_2018 together).
+# Manual tests only (model/resource still generated) - test configs keep sites/hierarchy_uuids mutually exclusive.
 ---
 name: Topology Hub Spoke
 model: topology_hubspoke
@@ -7,6 +7,7 @@ minimum_version: 20.15.0
 has_version: true
 id_attribute: id
 test_tags: [SDWAN_2015]
+skip_templates: ["resource_test.go", "data_source_test.go"]
 skip_minimum_test: true
 no_data_source_name_query: true
 parcel_type: feature

--- a/gen/definitions/profile_parcels/topology_mesh.yaml
+++ b/gen/definitions/profile_parcels/topology_mesh.yaml
@@ -1,4 +1,4 @@
-# Manual tests only (model/resource still generated) - test configs keep sites/hierarchy_uuids mutually exclusive (CI sets SDWAN_2015 and SDWAN_2018 together).
+# Manual tests only (model/resource still generated) - test configs keep sites/hierarchy_uuids mutually exclusive.
 ---
 name: Topology Mesh
 rest_endpoint: /v1/feature-profile/sdwan/topology/%v/mesh
@@ -6,6 +6,7 @@ minimum_version: 20.15.0
 has_version: true
 id_attribute: id
 test_tags: [SDWAN_2015]
+skip_templates: ["resource_test.go", "data_source_test.go"]
 skip_minimum_test: true
 no_data_source_name_query: true
 parcel_type: feature

--- a/internal/provider/data_source_sdwan_topology_custom_control_feature_test.go
+++ b/internal/provider/data_source_sdwan_topology_custom_control_feature_test.go
@@ -17,6 +17,8 @@
 
 package provider
 
+// NOTE: Hand-maintained (skip_templates in topology_custom_control.yaml) - keep sites/hierarchy_uuids mutually exclusive.
+
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"os"
@@ -88,17 +90,15 @@ func testAccDataSourceSdwanTopologyCustomControlProfileParcelConfig() string {
 	config += `	feature_profile_id = sdwan_topology_feature_profile.test.id` + "\n"
 	config += `	default_action = "reject"` + "\n"
 	config += `	target_level = "SITE"` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
+	if os.Getenv("SDWAN_2018") != "" {
+		config += `	target_inbound_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
 		config += `	target_inbound_sites = ["SITE_100"]` + "\n"
 	}
 	if os.Getenv("SDWAN_2018") != "" {
-		config += `	target_inbound_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
-	}
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	target_outbound_sites = ["SITE_200"]` + "\n"
-	}
-	if os.Getenv("SDWAN_2018") != "" {
 		config += `	target_outbound_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	target_outbound_sites = ["SITE_200"]` + "\n"
 	}
 	config += `	sequences = [{` + "\n"
 	config += `	  id = 1` + "\n"
@@ -110,11 +110,10 @@ func testAccDataSourceSdwanTopologyCustomControlProfileParcelConfig() string {
 	config += `		omp_tag = 100` + "\n"
 	config += `		origin = "connected"` + "\n"
 	config += `		originator = "1.2.3.4"` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `		site = ["site_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `		hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `		site = ["site_100"]` + "\n"
 	}
 	config += `		tloc_ip = "1.2.3.4"` + "\n"
 	config += `		tloc_color = "bronze"` + "\n"

--- a/internal/provider/data_source_sdwan_topology_hub_spoke_feature_test.go
+++ b/internal/provider/data_source_sdwan_topology_hub_spoke_feature_test.go
@@ -17,6 +17,8 @@
 
 package provider
 
+// NOTE: Hand-maintained (skip_templates in topology_hubspoke.yaml) - keep sites/hierarchy_uuids mutually exclusive.
+
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"os"
@@ -74,26 +76,23 @@ func testAccDataSourceSdwanTopologyHubSpokeProfileParcelConfig() string {
 	config += ` description = "Terraform integration test"` + "\n"
 	config += `	feature_profile_id = sdwan_topology_feature_profile.test.id` + "\n"
 	config += `	target_vpns = ["service_lan_vpn1"]` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	selected_hubs = ["SITE_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `	selected_hierarchy_hubs = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	selected_hubs = ["SITE_100"]` + "\n"
 	}
 	config += `	spokes = [{` + "\n"
 	config += `	  name = "spoke1"` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	  spoke_sites = ["SITE_200"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `	  spoke_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	  spoke_sites = ["SITE_200"]` + "\n"
 	}
 	config += `	  hub_sites = [{` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `		sites = ["SITE_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `		hub_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `		sites = ["SITE_100"]` + "\n"
 	}
 	config += `		preference = 1` + "\n"
 	config += `	}]` + "\n"

--- a/internal/provider/data_source_sdwan_topology_mesh_feature_test.go
+++ b/internal/provider/data_source_sdwan_topology_mesh_feature_test.go
@@ -17,6 +17,8 @@
 
 package provider
 
+// NOTE: Hand-maintained (skip_templates in topology_mesh.yaml) - keep sites/hierarchy_uuids mutually exclusive.
+
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"os"
@@ -72,11 +74,10 @@ func testAccDataSourceSdwanTopologyMeshProfileParcelConfig() string {
 	config += ` description = "Terraform integration test"` + "\n"
 	config += `	feature_profile_id = sdwan_topology_feature_profile.test.id` + "\n"
 	config += `	target_vpns = ["service_lan_vpn1"]` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	sites = ["SITE_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `	hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	sites = ["SITE_100"]` + "\n"
 	}
 	config += `}` + "\n"
 

--- a/internal/provider/resource_sdwan_topology_custom_control_feature_test.go
+++ b/internal/provider/resource_sdwan_topology_custom_control_feature_test.go
@@ -17,6 +17,8 @@
 
 package provider
 
+// NOTE: Hand-maintained (skip_templates in topology_custom_control.yaml) - keep sites/hierarchy_uuids mutually exclusive.
+
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"os"
@@ -93,17 +95,15 @@ func testAccSdwanTopologyCustomControlProfileParcelConfig_all() string {
 	config += `	feature_profile_id = sdwan_topology_feature_profile.test.id` + "\n"
 	config += `	default_action = "reject"` + "\n"
 	config += `	target_level = "SITE"` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
+	if os.Getenv("SDWAN_2018") != "" {
+		config += `	target_inbound_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
 		config += `	target_inbound_sites = ["SITE_100"]` + "\n"
 	}
 	if os.Getenv("SDWAN_2018") != "" {
-		config += `	target_inbound_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
-	}
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	target_outbound_sites = ["SITE_200"]` + "\n"
-	}
-	if os.Getenv("SDWAN_2018") != "" {
 		config += `	target_outbound_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	target_outbound_sites = ["SITE_200"]` + "\n"
 	}
 	config += `	sequences = [{` + "\n"
 	config += `	  id = 1` + "\n"
@@ -115,11 +115,10 @@ func testAccSdwanTopologyCustomControlProfileParcelConfig_all() string {
 	config += `		omp_tag = 100` + "\n"
 	config += `		origin = "connected"` + "\n"
 	config += `		originator = "1.2.3.4"` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `		site = ["site_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `		hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `		site = ["site_100"]` + "\n"
 	}
 	config += `		tloc_ip = "1.2.3.4"` + "\n"
 	config += `		tloc_color = "bronze"` + "\n"

--- a/internal/provider/resource_sdwan_topology_hub_spoke_feature_test.go
+++ b/internal/provider/resource_sdwan_topology_hub_spoke_feature_test.go
@@ -17,6 +17,8 @@
 
 package provider
 
+// NOTE: Hand-maintained (skip_templates in topology_hubspoke.yaml) - keep sites/hierarchy_uuids mutually exclusive.
+
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"os"
@@ -79,26 +81,23 @@ func testAccSdwanTopologyHubSpokeProfileParcelConfig_all() string {
 	config += ` description = "Terraform integration test"` + "\n"
 	config += `	feature_profile_id = sdwan_topology_feature_profile.test.id` + "\n"
 	config += `	target_vpns = ["service_lan_vpn1"]` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	selected_hubs = ["SITE_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `	selected_hierarchy_hubs = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	selected_hubs = ["SITE_100"]` + "\n"
 	}
 	config += `	spokes = [{` + "\n"
 	config += `	  name = "spoke1"` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	  spoke_sites = ["SITE_200"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `	  spoke_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	  spoke_sites = ["SITE_200"]` + "\n"
 	}
 	config += `	  hub_sites = [{` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `		sites = ["SITE_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `		hub_hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `		sites = ["SITE_100"]` + "\n"
 	}
 	config += `		preference = 1` + "\n"
 	config += `	}]` + "\n"

--- a/internal/provider/resource_sdwan_topology_mesh_feature_test.go
+++ b/internal/provider/resource_sdwan_topology_mesh_feature_test.go
@@ -17,6 +17,8 @@
 
 package provider
 
+// NOTE: Hand-maintained (skip_templates in topology_mesh.yaml) - keep sites/hierarchy_uuids mutually exclusive.
+
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"os"
@@ -77,11 +79,10 @@ func testAccSdwanTopologyMeshProfileParcelConfig_all() string {
 	config += ` description = "Terraform integration test"` + "\n"
 	config += `	feature_profile_id = sdwan_topology_feature_profile.test.id` + "\n"
 	config += `	target_vpns = ["service_lan_vpn1"]` + "\n"
-	if os.Getenv("SDWAN_2015") != "" {
-		config += `	sites = ["SITE_100"]` + "\n"
-	}
 	if os.Getenv("SDWAN_2018") != "" {
 		config += `	hierarchy_uuids = [sdwan_network_hierarchy_node.network_hierarchy_node_site_test.id]` + "\n"
+	} else if os.Getenv("SDWAN_2015") != "" {
+		config += `	sites = ["SITE_100"]` + "\n"
 	}
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
fix: keep topology sites/hierarchy_uuids test families mutually exclusive
